### PR TITLE
ScikitLearn glue

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ PDMats 0.3-
 Docile 0.4.5-
 Distances 0.2-
 ArrayViews 0.6-
+ScikitLearnBase 0.0.1

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -6,6 +6,10 @@ import Base.show
 # Description
 Fits a Gaussian process to a set of training points. The Gaussian process is defined in terms of its mean and covaiance (kernel) functions, which are user defined. As a default it is assumed that the observations are noise free.
 
+# Constructors:
+    GP(x, y, m, k, logNoise)
+    GP(; m=MeanZero(), k=SE(0.0, 0.0), logNoise=-1e8) # observation-free constructor
+
 # Arguments:
 * `x::Matrix{Float64}`: Training inputs
 * `y::Vector{Float64}`: Observations
@@ -35,7 +39,11 @@ type GP
         gp = new(x, y, dim, nobsv, logNoise, m, k)
         update_mll!(gp)
         return gp
-   end
+    end
+    function GP(; m=MeanZero(), k=SE(0.0, 0.0), logNoise=-1e8)
+        # We could leave x/y/dim/nobsv undefined if we reordered the fields
+        new(zeros(Float64,0,0), zeros(Float64, 0), 0, 0, logNoise, m, k)
+    end
 end
 
 # Creates GP object for 1D case

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -28,5 +28,8 @@ end
 
 @glue Gadfly
 @glue Winston
+# This does not require @glue because it uses the interface defined in
+# ScikitLearnBase, which is a skeleton package.
+include("glue/ScikitLearn.jl")
 
 end # module

--- a/src/glue/ScikitLearn.jl
+++ b/src/glue/ScikitLearn.jl
@@ -1,0 +1,114 @@
+# Implement the ScikitLearnBase.jl interface
+
+import ScikitLearnBase
+
+ScikitLearnBase.is_classifier(::GP) = false
+
+function ScikitLearnBase.fit!(gp::GP, X::Matrix{Float64}, y::Vector{Float64})
+    gp.x = X' # ScikitLearn's X is (n_samples, n_features)
+    gp.y = y
+    gp.dim, gp.nobsv = size(gp.x)
+    length(y) == gp.nobsv || throw(ArgumentError("Input and output observations must have consistent dimensions."))
+    update_mll!(gp)
+    return gp
+end
+
+function ScikitLearnBase.predict(gp::GP, X::Matrix{Float64}; eval_MSE::Bool=false)
+    mu, Sigma = predict(gp, X'; full_cov=false)
+    if eval_MSE
+        return mu, Sigma
+    else
+        return mu
+    end
+end
+
+# This is a default - arbitrary scoring functions can be passed to GridSearchCV
+function ScikitLearnBase.score(gp::GP, x, y)
+    # I use MSE here for simplicity. Is that equivalent to the likelihood for
+    # gaussian processes?
+    # It would make sense to use the marginal likelihood for hyperparameter
+    # tuning (like optimize.jl does), but GridSearchCV isn't designed for that.
+    return -mean((ScikitLearnBase.predict(gp, x) - y) .^ 2)
+end
+
+ScikitLearnBase.clone(gp::GP) = GP(; m=ScikitLearnBase.clone(gp.m),
+                                   k=ScikitLearnBase.clone(gp.k),
+                                   logNoise=gp.logNoise)
+
+# Means and Kernels are small objects, and they are not fit to the data (except
+# through hyperparameter tuning), so `deepcopy` is appropriate (if a bit lazy)
+ScikitLearnBase.clone(m::Mean) = deepcopy(m)
+ScikitLearnBase.clone(k::Kernel) = deepcopy(k)
+
+################################################################################
+## GaussianProcesses.jl has a get_params function, which returns a
+## Vector{Float64}. We use it to implement ScikitLearnBase.get_params, which
+## must return a Symbol => value dictionary. Likewise for set_params!
+
+function ScikitLearnBase.get_params(gp::GP)
+    add_prefix(pref, di) =
+        Dict([symbol(pref, param)=>value for (param, value) in di])
+    merge(add_prefix(:m_, ScikitLearnBase.get_params(gp.m)),
+          add_prefix(:k_, ScikitLearnBase.get_params(gp.k)),
+          Dict(:logNoise=>gp.logNoise))
+end
+
+function ScikitLearnBase.get_params(obj::Union{Mean, Kernel})
+    params = get_params(obj) # GaussianProcesses' get_params
+    names = get_param_names(obj)
+    @assert length(params) == length(names) # sanity check
+    return Dict(zip(names, params))
+end
+
+
+function ScikitLearnBase.set_params!(gp::GP; params...)
+    m_params = Dict()
+    k_params = Dict()
+    for (name, value) in params
+        sname = string(name)
+        if startswith(sname, "m_")
+            m_params[symbol(sname[3:end])] = value
+        elseif startswith(sname, "k_")
+            k_params[symbol(sname[3:end])] = value
+        else
+            @assert name == :logNoise "Unknown parameter passed to set_params!: $name"
+            gp.logNoise = value
+        end
+    end
+    ScikitLearnBase.set_params!(gp.m; m_params...)
+    ScikitLearnBase.set_params!(gp.k; k_params...)
+    gp
+end
+
+function ScikitLearnBase.set_params!(obj::Union{Mean, Kernel}; params...)
+    # In ScikitLearn, params need not contain all the parameters, so the
+    # code is different from get_params
+    names = get_param_names(obj)
+    # Get current parameter vector
+    hyp = copy(get_params(obj))
+    # Update it
+    for (name, value) in params
+        ind = findfirst(names, name)
+        @assert ind > 0 "Unknown parameter passed to set_params!: $name"
+        hyp[ind] = value
+    end
+    set_params!(obj, hyp)
+    obj
+end
+
+################################################################################
+# get_param_names definitions
+# Maybe they should be moved next to each Kernel and Mean definition?
+
+# This generates names like [:ll_1, :ll_2, ...] for parameter vectors
+get_param_names(n::Int, prefix::Symbol) = [symbol(prefix, :_, i) for i in 1:n]
+get_param_names(v::Vector, prefix::Symbol) = get_param_names(length(v), prefix)
+
+# Kernels
+get_param_names(::SEIso) = [:ll, :lσ]
+get_param_names(k::SEArd) = vcat(get_param_names(k.ℓ2, :ll), :lσ)
+
+# Means
+get_param_names(::MeanConst) = [:β]
+
+# TODO: fill in for all Kernels and Means

--- a/src/glue/ScikitLearn.jl
+++ b/src/glue/ScikitLearn.jl
@@ -98,17 +98,36 @@ end
 
 ################################################################################
 # get_param_names definitions
-# Maybe they should be moved next to each Kernel and Mean definition?
 
 # This generates names like [:ll_1, :ll_2, ...] for parameter vectors
 get_param_names(n::Int, prefix::Symbol) = [symbol(prefix, :_, i) for i in 1:n]
 get_param_names(v::Vector, prefix::Symbol) = get_param_names(length(v), prefix)
 
-# Kernels
-get_param_names(::SEIso) = [:ll, :lσ]
-get_param_names(k::SEArd) = vcat(get_param_names(k.ℓ2, :ll), :lσ)
+# Fallback. Yields names like :Matl2Iso_param_1 => 0.5
+# Ideally this is never used, because the names are uninformative.
+get_param_names(obj::Union{Kernel, Mean}) =
+    get_param_names(num_params(obj),
+                    symbol(typeof(obj).name.name, :_param_))
 
-# Means
-get_param_names(::MeanConst) = [:β]
+""" `composite_param_names(objects, prefix)`, where `objects` is a
+vector of kernels/means, calls `get_param_names` on each object and prefixes the
+name returned with `prefix` + object #. Eg.
 
-# TODO: fill in for all Kernels and Means
+    get_param_names(ProdKernel(Mat(1/2, 1/2, 1/2), SEArd([0.0, 1.0],0.0)))
+
+yields
+
+    :pk1_ll  
+    :pk1_lσ  
+    :pk2_ll_1
+    :pk2_ll_2
+    :pk2_lσ  
+"""
+function composite_param_names(objects, prefix)
+    p = Symbol[]
+    for (i, obj) in enumerate(objects)
+        append!(p, [symbol(prefix, i, :_, sym) for sym in get_param_names(obj)])
+    end
+    p
+end
+

--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -22,6 +22,7 @@ function kern(lin::LinArd, x::Vector{Float64}, y::Vector{Float64})
 end
 
 get_params(lin::LinArd) = lin.ll
+get_param_names(lin::LinArd) = get_param_names(lin.ll, :ll)
 num_params(lin::LinArd) = lin.dim
 
 function set_params!(lin::LinArd, hyp::Vector{Float64})

--- a/src/kernels/lin_iso.jl
+++ b/src/kernels/lin_iso.jl
@@ -20,6 +20,7 @@ function kern(lin::LinIso, x::Vector{Float64}, y::Vector{Float64})
 end
 
 get_params(lin::LinIso) = Float64[lin.ll]
+get_param_names(lin::LinIso) = [:ll]
 num_params(lin::LinIso) = 1
 
 function set_params!(lin::LinIso, hyp::Vector{Float64})

--- a/src/kernels/mat12_ard.jl
+++ b/src/kernels/mat12_ard.jl
@@ -23,6 +23,7 @@ function set_params!(mat::Mat12Ard, hyp::Vector{Float64})
 end
 
 get_params(mat::Mat12Ard) = [log(mat.ℓ); log(mat.σ2)/2.0]
+get_param_names(mat::Mat12Ard) = [get_param_names(mat.ℓ, :ll); :lσ]
 num_params(mat::Mat12Ard) = mat.dim
 
 metric(mat::Mat12Ard) = WeightedEuclidean(1.0./(mat.ℓ))

--- a/src/kernels/mat12_iso.jl
+++ b/src/kernels/mat12_iso.jl
@@ -21,6 +21,7 @@ function set_params!(mat::Mat12Iso, hyp::Vector{Float64})
 end
 
 get_params(mat::Mat12Iso) = Float64[log(mat.ℓ), log(mat.σ2)/2.0]
+get_param_names(mat::Mat12Iso) = [:ll, :lσ]
 num_params(mat::Mat12Iso) = 2
 
 metric(mat::Mat12Iso) = Euclidean()

--- a/src/kernels/mat32_ard.jl
+++ b/src/kernels/mat32_ard.jl
@@ -23,6 +23,7 @@ function set_params!(mat::Mat32Ard, hyp::Vector{Float64})
 end
 
 get_params(mat::Mat32Ard) = [log(mat.ℓ); log(mat.σ2)/2.0]
+get_param_names(mat::Mat32Ard) = [get_param_names(mat.ℓ, :ll); :lσ]
 num_params(mat::Mat32Ard) = mat.dim
 
 metric(mat::Mat32Ard) = WeightedEuclidean(1.0./(mat.ℓ))

--- a/src/kernels/mat32_iso.jl
+++ b/src/kernels/mat32_iso.jl
@@ -21,6 +21,7 @@ function set_params!(mat::Mat32Iso, hyp::Vector{Float64})
 end
 
 get_params(mat::Mat32Iso) = Float64[log(mat.ℓ), log(mat.σ2)/2.0]
+get_param_names(mat::Mat32Iso) = [:ll, :lσ]
 num_params(mat::Mat32Iso) = 2
 
 metric(mat::Mat32Iso) = Euclidean()

--- a/src/kernels/mat52_ard.jl
+++ b/src/kernels/mat52_ard.jl
@@ -23,6 +23,7 @@ function set_params!(mat::Mat52Ard, hyp::Vector{Float64})
 end
 
 get_params(mat::Mat52Ard) = [log(mat.ℓ); log(mat.σ2)/2.0]
+get_param_names(mat::Mat52Ard) = [get_param_names(mat.ℓ, :ll); :lσ]
 num_params(mat::Mat52Ard) = mat.dim
 
 metric(mat::Mat52Ard) = WeightedEuclidean(1.0./(mat.ℓ))

--- a/src/kernels/mat52_iso.jl
+++ b/src/kernels/mat52_iso.jl
@@ -20,6 +20,7 @@ function set_params!(mat::Mat52Iso, hyp::Vector{Float64})
     mat.ℓ, mat.σ2 = exp(hyp[1]), exp(2.0*hyp[2])
 end
 get_params(mat::Mat52Iso) = Float64[log(mat.ℓ), log(mat.σ2)/2.0]
+get_param_names(mat::Mat52Iso) = [:ll, :lσ]
 num_params(mat::Mat52Iso) = 2
 
 metric(mat::Mat52Iso) = Euclidean()

--- a/src/kernels/noise.jl
+++ b/src/kernels/noise.jl
@@ -22,6 +22,7 @@ function kern(noise::Noise, x::Vector{Float64}, y::Vector{Float64})
 end
 
 get_params(noise::Noise) = Float64[noise.lσ]
+get_param_names(noise::Noise) = [:lσ]
 num_params(noise::Noise) = 1
 
 function set_params!(noise::Noise, hyp::Vector{Float64})

--- a/src/kernels/periodic.jl
+++ b/src/kernels/periodic.jl
@@ -25,6 +25,7 @@ function kern(peri::Periodic, x::Vector{Float64}, y::Vector{Float64})
 end
 
 get_params(peri::Periodic) = Float64[peri.ll, peri.lσ, peri.lp]
+get_param_names(peri::Periodic) = [:ll, :lσ, :lp]
 num_params(peri::Periodic) = 3
 
 function set_params!(peri::Periodic, hyp::Vector{Float64})

--- a/src/kernels/poly.jl
+++ b/src/kernels/poly.jl
@@ -26,6 +26,7 @@ function kern(poly::Poly, x::Vector{Float64}, y::Vector{Float64})
 end
 
 get_params(poly::Poly) = Float64[poly.lc, poly.lσ]
+get_param_names(poly::Poly) = [:lc, :lσ]
 num_params(poly::Poly) = 2
 
 function set_params!(poly::Poly, hyp::Vector{Float64})

--- a/src/kernels/prod_kernel.jl
+++ b/src/kernels/prod_kernel.jl
@@ -43,6 +43,8 @@ function get_params(prodkern::ProdKernel)
     p
 end
 
+get_param_names(prodkern::ProdKernel) = composite_param_names(prodkern.kerns, :pk)
+
 function num_params(prodkern::ProdKernel)
     n = 0
     for k in prodkern.kerns

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -26,6 +26,7 @@ function set_params!(rq::RQArd, hyp::Vector{Float64})
 end
 
 get_params(rq::RQArd) = [log(rq.ℓ2)/2.0; log(rq.σ2)/2.0; log(rq.α)]
+get_param_names(rq::RQArd) = [get_param_names(rq.ℓ2, :ll); :lσ; :lα]
 num_params(rq::RQArd) = rq.dim
 
 metric(rq::RQArd) = WeightedSqEuclidean(1.0./(rq.ℓ2))

--- a/src/kernels/rq_iso.jl
+++ b/src/kernels/rq_iso.jl
@@ -23,6 +23,7 @@ function set_params!(rq::RQIso, hyp::Vector{Float64})
 end
 
 get_params(rq::RQIso) = Float64[log(rq.ℓ2)/2.0, log(rq.σ2)/2.0, log(rq.α)]
+get_param_names(rq::RQIso) = [:ll, :lσ, :lα]
 num_params(rq::RQIso) = 3
 
 metric(rq::RQIso) = SqEuclidean()

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -23,6 +23,7 @@ function set_params!(se::SEArd, hyp::Vector{Float64})
 end
 
 get_params(se::SEArd) = [log(se.ℓ2)/2.0; log(se.σ2)/2.0]
+get_param_names(k::SEArd) = [get_param_names(k.ℓ2, :ll); :lσ]
 num_params(se::SEArd) = se.dim
 
 metric(se::SEArd) = WeightedSqEuclidean(1.0./(se.ℓ2))

--- a/src/kernels/se_iso.jl
+++ b/src/kernels/se_iso.jl
@@ -19,6 +19,7 @@ function set_params!(se::SEIso, hyp::Vector{Float64})
 end
 
 get_params(se::SEIso) = Float64[log(se.ℓ2)/2.0, log(se.σ2)/2.0]
+get_param_names(::SEIso) = [:ll, :lσ]
 num_params(se::SEIso) = 2
 
 metric(se::SEIso) = SqEuclidean()

--- a/src/kernels/sum_kernel.jl
+++ b/src/kernels/sum_kernel.jl
@@ -63,6 +63,8 @@ function get_params(sumkern::SumKernel)
     p
 end
 
+get_param_names(sumkern::SumKernel) = composite_param_names(sumkern.kerns, :sk)
+
 function num_params(sumkern::SumKernel)
     n = 0
     for k in sumkern.kerns

--- a/src/means/mConst.jl
+++ b/src/means/mConst.jl
@@ -24,6 +24,7 @@ MeanZero() = MeanConst(0.0)
 meanf(mConst::MeanConst,x::Matrix{Float64}) =  fill(mConst.β, size(x,2))
 
 get_params(mConst::MeanConst) = Float64[mConst.β]
+get_param_names(::MeanConst) = [:β]
 num_params(mConst::MeanConst) = 1
 function set_params!(mConst::MeanConst, hyp::Vector{Float64})
     length(hyp) == 1 || throw(ArgumentError("Constant mean function only has 1 parameter"))

--- a/src/means/mLin.jl
+++ b/src/means/mLin.jl
@@ -17,6 +17,7 @@ end
 meanf(mLin::MeanLin,x::Matrix{Float64}) =  x'mLin.β
 
 get_params(mLin::MeanLin) = mLin.β
+get_param_names(::MeanLin) = [:β]
 num_params(mLin::MeanLin) = mLin.dim
 
 function set_params!(mLin::MeanLin, hyp::Vector{Float64})

--- a/src/means/mPoly.jl
+++ b/src/means/mPoly.jl
@@ -28,6 +28,7 @@ function meanf(mPoly::MeanPoly,x::Matrix{Float64})
 end
 
 get_params(mPoly::MeanPoly) = vec(mPoly.β)
+get_param_names(mPoly::MeanPoly) = get_param_names(mPoly.β, :β)
 num_params(mPoly::MeanPoly) = mPoly.dim * mPoly.deg
 function set_params!(mPoly::MeanPoly, hyp::Vector{Float64})
     num_param = mPoly.dim * mPoly.deg

--- a/src/means/prod_mean.jl
+++ b/src/means/prod_mean.jl
@@ -34,6 +34,8 @@ function get_params(prodmean::ProdMean)
     p
 end
 
+get_param_names(prodmean::ProdMean) = composite_param_names(prodmean.means, :pm)
+
 function num_params(prodmean::ProdMean)
     n = 0
     for m in prodmean.means

--- a/src/means/sum_mean.jl
+++ b/src/means/sum_mean.jl
@@ -34,6 +34,8 @@ function get_params(summean::SumMean)
     p
 end
 
+get_param_names(summean::SumMean) = composite_param_names(summean.means, :sm)
+
 function num_params(summean::SumMean)
     n = 0
     for m in summean.means

--- a/test/test_GP.jl
+++ b/test/test_GP.jl
@@ -1,4 +1,5 @@
 using GaussianProcesses
+import ScikitLearnBase
 
 d, n = 10, 20
 
@@ -16,6 +17,14 @@ function test_pred_matches_obs(gp::GP)
 end
 
 test_pred_matches_obs(gp)
+
+function sk_test_pred_matches_obs() # ScikitLearn interface test
+    gp_sk = ScikitLearnBase.fit!(GP(), x', y)
+    y_pred = ScikitLearnBase.predict(gp_sk, x')
+    @test_approx_eq_eps maximum(abs(gp_sk.y - y_pred)) 0.0 1e-4
+end
+
+sk_test_pred_matches_obs()
 
 # Modify kernel and update
 gp.k.ℓ2 = 4.0

--- a/test/test_kernels.jl
+++ b/test/test_kernels.jl
@@ -1,4 +1,5 @@
 using GaussianProcesses, Base.Test
+using GaussianProcesses: get_params, get_param_names, num_params
 
 function test_crossKern(kern::Kernel, x::Matrix{Float64})
     spec = GaussianProcesses.crossKern(x, kern)
@@ -20,6 +21,7 @@ end
 function test_Kernel(kern::Kernel, x::Matrix{Float64})
     t = typeof(kern)
     println("\tTesting $(t)...")
+    @assert length(get_param_names(kern)) == length(get_params(kern)) == num_params(kern)
     test_crossKern(kern, x)
     test_grad_stack(kern, x)
 end


### PR DESCRIPTION
Follow-up to #16. @fairbrot I kept the `GP(; m=MeanZero(), k=SE(0.0,0.0))` constructor. Let me know if you have better defaults to propose. ScikitLearn's `get_params` returns a dictionary, so I have to write `get_param_names` for every Kernel and Mean type in order to implement it. I did it for `MeanConst` and `SEArd` so far. If it looks OK, I'll write it for the other kernels too.

I used [this notebook](https://github.com/cstjean/ScikitLearn.jl/blob/master/examples/GaussianProcessesNative.ipynb) for testing it out, it shows how to use GridSearchCV for hyperparameter tuning (Optim.jl is better for stand-alone models, but GridSearchCV will also work with arbitrary ScikitLearn pipelines).