### PR TITLE
Have rand function return one sample by default

### DIFF
--- a/src/GP.jl
+++ b/src/GP.jl
@@ -152,14 +152,14 @@ function rand!(gp::GP, x::Matrix{Float64}, A::DenseMatrix)
     return broadcast!(+, A, μ, unwhiten!(Σ,randn(nobsv, n_sample)))
 end
 
-function rand(gp::GP, x::Matrix{Float64}, n::Int)
+function rand(gp::GP, x::Matrix{Float64}, n::Int=1)
     nobsv=size(x,2)
     A = Array(Float64, nobsv, n)
     return rand!(gp, x, A)
 end
 
 # Sample from 1D GP
-rand(gp::GP, x::Vector{Float64}, n::Int) = rand(gp, x', n)
+rand(gp::GP, x::Vector{Float64}, n::Int=1) = rand(gp, x', n)
 
 
 function get_params(gp::GP; noise::Bool=true, mean::Bool=true, kern::Bool=true)


### PR DESCRIPTION
I think this makes sense as a default, and is consistent with the behavior of (e.g.) `Distributions.jl`. Short example:

```julia
using GaussianProcesses
gp = GP()     
range = collect(linspace(-5,5));
Yr=rand(gp,range) # assumes n=1
```

Yr is a `50x1 Array{Float64,2}`.