### PR TITLE
faster implementation of cov and grad_stack for linear kernels

### DIFF
--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -21,6 +21,11 @@ function cov(lin::LinArd, x::Vector{Float64}, y::Vector{Float64})
     return K
 end
 
+function cov(lin::LinArd, X::Matrix{Float64}, data::EmptyData)
+    ell = exp(lin.ll)
+    return (X./ell)' * (X./ell)
+end
+
 get_params(lin::LinArd) = lin.ll
 get_param_names(lin::LinArd) = get_param_names(lin.ll, :ll)
 num_params(lin::LinArd) = lin.dim
@@ -34,4 +39,12 @@ function grad_kern(lin::LinArd, x::Vector{Float64}, y::Vector{Float64})
     ell = exp(lin.ll)
     dK_ell = -2.0*(x./ell).*(y./ell)
     return dK_ell
+end
+
+function grad_stack!(stack::AbstractArray, lin::LinArd, X::Matrix{Float64}, data::EmptyData)
+    ell = exp(lin.ll)
+    d, nobsv = size(X)
+    for j in 1:d
+        stack[:,:,j] = ((-2.0/ell[j]^2).*X[j,:]) * X[j,:]'
+    end
 end

--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -45,6 +45,6 @@ function grad_stack!(stack::AbstractArray, lin::LinArd, X::Matrix{Float64}, data
     ell = exp(lin.ll)
     d, nobsv = size(X)
     for j in 1:d
-        stack[:,:,j] = ((-2.0/ell[j]^2).*X[j,:]) * X[j,:]'
+        stack[:,:,j] = ((-2.0/ell[j]^2).*vec(X[j,:])) * vec(X[j,:])'
     end
 end

--- a/src/kernels/lin_iso.jl
+++ b/src/kernels/lin_iso.jl
@@ -19,6 +19,11 @@ function cov(lin::LinIso, x::Vector{Float64}, y::Vector{Float64})
     return K
 end
 
+function cov(lin::LinIso, X::Matrix{Float64}, data::EmptyData)
+    ell = exp(lin.ll)
+    return ((1/ell^2).*X') * X
+end
+
 get_params(lin::LinIso) = Float64[lin.ll]
 get_param_names(lin::LinIso) = [:ll]
 num_params(lin::LinIso) = 1
@@ -34,4 +39,9 @@ function grad_kern(lin::LinIso, x::Vector{Float64}, y::Vector{Float64})
     dK_ell = -2.0*dot(x,y)/ell^2
     dK_theta = [dK_ell]
     return dK_theta
+end
+
+function grad_stack!(stack::AbstractArray, lin::LinIso, X::Matrix{Float64}, data::EmptyData)
+    ell = exp(lin.ll)
+    stack[:,:,1] = ((-2.0/ell^2).*X') * X
 end


### PR DESCRIPTION
Some of my code was spending a lot of time on computing covariance matrices and gradients for linear kernels, so I wrote some faster implementations.