### PR TITLE
revamp gradients implementations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ Optim 0.5-
 PDMats 0.3-
 Distances 0.2-
 ScikitLearnBase 0.0.1
-Compat 0.9
+Compat 0.9.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.4
 Optim 0.5-
 PDMats 0.3-
 Distances 0.2-
-ArrayViews 0.6-
 ScikitLearnBase 0.0.1
+Compat 0.9

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -1,7 +1,7 @@
 module GaussianProcesses
 using Optim, PDMats, Distances
 using Compat
-import Compat: view
+import Compat: view, cholfact!
 
 import Base: +, *
 import Base: rand, rand!, mean, cov, push!

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -1,5 +1,7 @@
 module GaussianProcesses
-using Optim, PDMats, Distances, ArrayViews
+using Optim, PDMats, Distances
+using Compat
+import Compat: view
 
 import Base: +, *
 import Base: rand, rand!, mean, cov, push!

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -19,7 +19,7 @@ include("optimize.jl")
 # This approach to loading supported plotting packages is taken from the "KernelDensity" package
 macro glue(pkg)
     path = joinpath(dirname(@__FILE__),"glue",string(pkg,".jl"))
-    init = symbol(string(pkg,"_init"))
+    init = Symbol(string(pkg,"_init"))
     quote
         $(esc(init))() = Base.include($path)
         isdefined(Main,$(QuoteNode(pkg))) && $(esc(init))()

--- a/src/glue/ScikitLearn.jl
+++ b/src/glue/ScikitLearn.jl
@@ -48,7 +48,7 @@ ScikitLearnBase.clone(k::Kernel) = deepcopy(k)
 
 function ScikitLearnBase.get_params(gp::GP)
     add_prefix(pref, di) =
-        Dict([symbol(pref, param)=>value for (param, value) in di])
+        Dict(Symbol(pref, param)=>value for (param, value) in di)
     merge(add_prefix(:m_, ScikitLearnBase.get_params(gp.m)),
           add_prefix(:k_, ScikitLearnBase.get_params(gp.k)),
           Dict(:logNoise=>gp.logNoise))
@@ -68,9 +68,9 @@ function ScikitLearnBase.set_params!(gp::GP; params...)
     for (name, value) in params
         sname = string(name)
         if startswith(sname, "m_")
-            m_params[symbol(sname[3:end])] = value
+            m_params[Symbol(sname[3:end])] = value
         elseif startswith(sname, "k_")
-            k_params[symbol(sname[3:end])] = value
+            k_params[Symbol(sname[3:end])] = value
         else
             @assert name == :logNoise "Unknown parameter passed to set_params!: $name"
             gp.logNoise = value

--- a/src/glue/ScikitLearn.jl
+++ b/src/glue/ScikitLearn.jl
@@ -46,9 +46,14 @@ ScikitLearnBase.clone(k::Kernel) = deepcopy(k)
 ## Vector{Float64}. We use it to implement ScikitLearnBase.get_params, which
 ## must return a Symbol => value dictionary. Likewise for set_params!
 
+function add_prefix(pref, di)
+    newdi = typeof(di)()
+    for (param,value) in di
+        newdi[Symbol(pref, param)] = value
+    end
+    return newdi
+end
 function ScikitLearnBase.get_params(gp::GP)
-    add_prefix(pref, di) =
-        Dict(Symbol(pref, param)=>value for (param, value) in di)
     merge(add_prefix(:m_, ScikitLearnBase.get_params(gp.m)),
           add_prefix(:k_, ScikitLearnBase.get_params(gp.k)),
           Dict(:logNoise=>gp.logNoise))

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -105,7 +105,7 @@ end
 function grad_stack!(stack::AbstractArray, k::Kernel, X::Matrix{Float64}, data::KernelData)
     npars = num_params(k)
     for p in 1:npars
-        grad_slice!(Base.view(stack,:,:,p),k,X,data,p)
+        grad_slice!(view(stack,:,:,p),k,X,data,p)
     end
     return stack
 end

--- a/src/kernels/lin.jl
+++ b/src/kernels/lin.jl
@@ -1,5 +1,7 @@
 # Linear covariance function
 
+@inline dotij(X::Matrix{Float64}, i::Int, j::Int, dim::Int) = sum((X[d,i]*X[d,j]) for d in 1:dim)
+@inline dotijp(X::Matrix{Float64}, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
 include("lin_iso.jl")
 include("lin_ard.jl")
 

--- a/src/kernels/lin.jl
+++ b/src/kernels/lin.jl
@@ -1,7 +1,13 @@
 # Linear covariance function
 
-@inline dotij(X::Matrix{Float64}, i::Int, j::Int, dim::Int) = sum((X[d,i]*X[d,j]) for d in 1:dim)
 @inline dotijp(X::Matrix{Float64}, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
+@inline function dotij(X::Matrix, i::Int, j::Int, dim::Int)
+	s=zero(eltype(X))
+	@inbounds @simd for p in 1:dim
+		s+=dotijp(X,i,j,p)
+	end
+	return s
+end
 include("lin_iso.jl")
 include("lin_ard.jl")
 

--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -10,41 +10,71 @@ k(x,x') = xᵀL⁻²x', where L = diag(ℓ₁,ℓ₂,...)
 * `ll::Vector{Float64}`: Log of the length scale ℓ
 """ ->
 type LinArd <: Kernel
-    ll::Vector{Float64}      # Log of Length scale
+    ℓ::Vector{Float64}      # Length Scale
     dim::Int                 # Number of hyperparameters
-    LinArd(ll::Vector{Float64}) = new(ll,size(ll,1))
+    LinArd(ll::Vector{Float64}) = new(exp(ll),size(ll,1))
 end
 
 function cov(lin::LinArd, x::Vector{Float64}, y::Vector{Float64})
-    ell = exp(lin.ll)
-    K = dot(x./ell,y./ell)
+    K = dot(x./lin.ℓ,y./lin.ℓ)
     return K
 end
 
-function cov(lin::LinArd, X::Matrix{Float64}, data::EmptyData)
-    ell = exp(lin.ll)
-    return (X./ell)' * (X./ell)
+type LinArdData <: KernelData
+    XtX_d::Array{Float64,3}
 end
 
-get_params(lin::LinArd) = lin.ll
-get_param_names(lin::LinArd) = get_param_names(lin.ll, :ll)
+function KernelData(k::LinArd, X::Matrix{Float64})
+    dim,n=size(X)
+    XtX_d = Array(Float64,n,n,dim)
+    for d in 1:dim
+        XtX_d[:,:,d] = Base.view(X,d,:) * Base.view(X,d,:)'
+        Base.LinAlg.copytri!(Base.view(XtX_d,:,:,d), 'U')
+    end
+    LinArdData(XtX_d)
+end
+kernel_data_key(k::LinArd, X::Matrix{Float64}) = :LinArdData
+function cov(lin::LinArd, X::Matrix{Float64})
+    K = (X./lin.ℓ)' * (X./lin.ℓ)
+    Base.LinAlg.copytri!(K, 'U')
+    return K
+end
+function cov!(cK::AbstractMatrix, lin::LinArd, X::Matrix{Float64}, data::LinArdData)
+    dim,n=size(X)
+    cK[:,:] = 0.0
+    for d in 1:dim
+        Base.LinAlg.axpy!(1/lin.ℓ[d]^2, Base.view(data.XtX_d,:,:,d), cK)
+    end
+    return cK
+end
+function cov(lin::LinArd, X::Matrix{Float64}, data::LinArdData)
+    nobsv=size(X,2)
+    K = zeros(Float64,nobsv,nobsv)
+    cov!(K,lin,X,data)
+    return K
+end
+
+get_params(lin::LinArd) = log(lin.ℓ)
+get_param_names(lin::LinArd) = get_param_names(lin.ℓ, :ll)
 num_params(lin::LinArd) = lin.dim
 
 function set_params!(lin::LinArd, hyp::Vector{Float64})
     length(hyp) == lin.dim || throw(ArgumentError("Linear ARD kernel has $(lin.dim) parameters"))
-    lin.ll = hyp
+    lin.ℓ = exp(hyp)
 end
 
-function grad_kern(lin::LinArd, x::Vector{Float64}, y::Vector{Float64})
-    ell = exp(lin.ll)
-    dK_ell = -2.0*(x./ell).*(y./ell)
-    return dK_ell
+@inline dk_dll(lin::LinArd, xy::Float64, d::Int) = -2.0*xy/lin.ℓ[d]^2
+@inline function dKij_dθp(lin::LinArd, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    if p<=dim
+        return dk_dll(lin, dotijp(X,i,j,p), p)
+    else
+        return NaN
+    end
 end
-
-function grad_stack!(stack::AbstractArray, lin::LinArd, X::Matrix{Float64}, data::EmptyData)
-    ell = exp(lin.ll)
-    d, nobsv = size(X)
-    for j in 1:d
-        stack[:,:,j] = ((-2.0/ell[j]^2).*vec(X[j,:])) * vec(X[j,:])'
+@inline function dKij_dθp(lin::LinArd, X::Matrix{Float64}, data::LinArdData, i::Int, j::Int, p::Int, dim::Int)
+    if p<=dim
+        return dk_dll(lin, data.XtX_d[i,j,p],p)
+    else
+        return NaN
     end
 end

--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -28,8 +28,8 @@ function KernelData(k::LinArd, X::Matrix{Float64})
     dim,n=size(X)
     XtX_d = Array(Float64,n,n,dim)
     for d in 1:dim
-        XtX_d[:,:,d] = Base.view(X,d,:) * Base.view(X,d,:)'
-        Base.LinAlg.copytri!(Base.view(XtX_d,:,:,d), 'U')
+        XtX_d[:,:,d] = view(X,d,:) * view(X,d,:)'
+        Base.LinAlg.copytri!(view(XtX_d,:,:,d), 'U')
     end
     LinArdData(XtX_d)
 end
@@ -43,7 +43,7 @@ function cov!(cK::AbstractMatrix, lin::LinArd, X::Matrix{Float64}, data::LinArdD
     dim,n=size(X)
     cK[:,:] = 0.0
     for d in 1:dim
-        Base.LinAlg.axpy!(1/lin.ℓ[d]^2, Base.view(data.XtX_d,:,:,d), cK)
+        Base.LinAlg.axpy!(1/lin.ℓ[d]^2, view(data.XtX_d,:,:,d), cK)
     end
     return cK
 end

--- a/src/kernels/lin_iso.jl
+++ b/src/kernels/lin_iso.jl
@@ -35,8 +35,10 @@ function cov(lin::LinIso, X::Matrix{Float64}, data::LinIsoData)
     return K
 end
 function cov!(cK::AbstractMatrix, lin::LinIso, X::Matrix{Float64}, data::LinIsoData)
-    copy!(cK, data.XtX)
-    cK[:,:] ./= lin.ℓ2
+    iℓ2 = 1/lin.ℓ2
+    @inbounds @simd for I in eachindex(cK,data.XtX)
+        cK[I] = data.XtX[I]*iℓ2
+    end
     return cK
 end
 

--- a/src/kernels/mat.jl
+++ b/src/kernels/mat.jl
@@ -1,4 +1,31 @@
 # A class of Matern isotropic functions including the Matrern 3/2 and 5/2, where d= 3 or 5. Also the exponential function, where d=1
+abstract MaternIso <: Isotropic
+abstract MaternARD <: StationaryARD
+
+@inline function dKij_dθp(mat::MaternARD, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    r=distij(metric(mat),X,i,j,dim)
+    if p <= dim
+        wdiffp=dist2ijk(metric(mat),X,i,j,p)
+        return wdiffp==0.0?0.0:dk_dll(mat,r,wdiffp)
+    elseif p==dim+1
+        return dk_dlσ(mat, r)
+    else
+        return NaN
+    end
+end
+@inline function dKij_dθp(mat::MaternARD, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(mat,X,i,j,p,dim)
+end
+
+@inline function dk_dθp(mat::MaternIso, r::Float64, p::Int)
+    if p==1
+        return r==0.0?0.0:dk_dll(mat, r)
+    elseif p==2
+        return dk_dlσ(mat, r)
+    else
+        return NaN
+    end
+end
 
 include("mat12_iso.jl")
 include("mat12_ard.jl")
@@ -39,8 +66,4 @@ function Mat(ν::Float64,ll::Vector{Float64}, lσ::Float64)
     end
     return kern
 end    
-
-
-
-
 

--- a/src/kernels/mat12_ard.jl
+++ b/src/kernels/mat12_ard.jl
@@ -4,49 +4,29 @@
 # Description
 Constructor for the ARD Matern 1/2 kernel (covariance)
 
-k(x,x') = σ²exp(-d/L^2), where d = |x-x'| and L = diag(ℓ₁,ℓ₂,...)
+k(x,x') = σ²exp(-d/L), where d = |x-x'| and L = diag(ℓ₁,ℓ₂,...)
 # Arguments:
 * `ll::Vector{Float64}`: Log of the length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
-type Mat12Ard <: StationaryARD
-    ℓ2::Vector{Float64}      # Log of length scale
+type Mat12Ard <: MaternARD
+    iℓ2::Vector{Float64}     # Inverse squared Length scale
     σ2::Float64              # Log of signal std
-    Mat12Ard(ll::Vector{Float64}, lσ::Float64) = new(2.0*exp(ll),exp(2.0*lσ))
+    Mat12Ard(ll::Vector{Float64}, lσ::Float64) = new(exp(-2.0*ll),exp(2.0*lσ))
 end
 
 function set_params!(mat::Mat12Ard, hyp::Vector{Float64})
     length(hyp) == num_params(mat) || throw(ArgumentError("Mat12 kernel only has $(num_params(mat)) parameters"))
-    d = length(mat.ℓ2)
-    mat.ℓ2  = exp(2.0*hyp[1:d])
+    d = length(mat.iℓ2)
+    mat.iℓ2  = exp(-2.0*hyp[1:d])
     mat.σ2 = exp(2.0*hyp[d+1])
 end
 
-get_params(mat::Mat12Ard) = [log(mat.ℓ2)/2.0; log(mat.σ2)/2.0]
-get_param_names(mat::Mat12Ard) = [get_param_names(mat.ℓ2, :ll); :lσ]
-num_params(mat::Mat12Ard) = length(mat.ℓ2) + 1
+get_params(mat::Mat12Ard) = [-log(mat.iℓ2)/2.0; log(mat.σ2)/2.0]
+get_param_names(mat::Mat12Ard) = [get_param_names(mat.iℓ2, :ll); :lσ]
+num_params(mat::Mat12Ard) = length(mat.iℓ2) + 1
 
-metric(mat::Mat12Ard) = WeightedEuclidean(1.0./(mat.ℓ2))
+metric(mat::Mat12Ard) = WeightedEuclidean(mat.iℓ2)
 cov(mat::Mat12Ard, r::Float64) = mat.σ2*exp(-r)
 
-function grad_kern(mat::Mat12Ard, x::Vector{Float64}, y::Vector{Float64})
-    r = distance(mat, x, y)
-    exp_r = exp(-r)
-    wdiff = ((x-y).^2)./mat.ℓ2
-    
-    g1 = (mat.σ2*wdiff*exp_r)/r
-    g2 = 2.0*mat.σ2*exp_r
-    
-    return [g1; g2]
-end
-
-function grad_stack!(stack::AbstractArray, mat::Mat12Ard, X::Matrix{Float64}, data::StationaryARDData)
-    d = size(X,1)
-    R = distance(mat, X, data)
-    stack[:,:,d+1] = mat.σ2 * exp(-R)
-    ck = view(stack, :, :, d+1)
-    broadcast!(*, view(stack, :, :, 1:d), data.dist_stack, reshape(1.0./mat.ℓ2, (1,1,d)), ck)
-    broadcast!(/, view(stack, :, :, 1:d), view(stack, :, :, 1:d), R)
-    stack[:,:, d+1] = 2.0 * ck
-    return stack
-end
+dk_dll(mat::Mat12Ard, r::Float64, wdiffp::Float64) = wdiffp/r*cov(mat,r)

--- a/src/kernels/mat12_iso.jl
+++ b/src/kernels/mat12_iso.jl
@@ -9,7 +9,7 @@ k(x,x') = σ²exp(-d/ℓ), where d=|x-x'|
 * `ll::Float64`: Log of the length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
-type Mat12Iso <: Isotropic
+type Mat12Iso <: MaternIso
     ℓ::Float64     # Length scale
     σ2::Float64    # Signal std
     Mat12Iso(ll::Float64, lσ::Float64) = new(exp(ll),exp(2*lσ))
@@ -27,27 +27,4 @@ num_params(mat::Mat12Iso) = 2
 metric(mat::Mat12Iso) = Euclidean()
 cov(mat::Mat12Iso, r::Float64) = mat.σ2*exp(-r/mat.ℓ)
 
-function grad_kern(mat::Mat12Iso, x::Vector{Float64}, y::Vector{Float64})
-    r = distance(mat,x,y)
-    exp_r = exp(-r/mat.ℓ)
-    
-    g1 = mat.σ2*r/mat.ℓ*exp_r  #dK_d(log ℓ)
-    g2 = 2.0*mat.σ2*exp_r      #dK_d(log σ)
-    return [g1,g2]
-end
-
-
-function grad_stack!(stack::AbstractArray, mat::Mat12Iso, X::Matrix{Float64}, data::IsotropicData)
-    nobsv = size(X,2)
-    R = distance(mat, X, data)
-    exp_R = exp(-R/mat.ℓ)
-
-    for i in 1:nobsv, j in 1:i
-        @inbounds stack[i,j,1] = mat.σ2*R[i,j]/mat.ℓ*exp_R[i,j] # dK_dℓ
-        @inbounds stack[j,i,1] = stack[i,j,1] 
-        @inbounds stack[i,j,2] = 2.0 * mat.σ2 * exp_R[i,j]    # dK_dσ
-        @inbounds stack[j,i,2] = stack[i,j,2] 
-    end
-    
-    return stack
-end
+@inline dk_dll(mat::Mat12Iso, r::Float64) = r/mat.ℓ*cov(mat,r)

--- a/src/kernels/mat32_iso.jl
+++ b/src/kernels/mat32_iso.jl
@@ -9,7 +9,7 @@ k(x,x') = σ²(1+√3*d/ℓ)exp(-√3*d/ℓ), where d = |x-x'|
 * `ll::Float64`: Log of the length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
-type Mat32Iso <: Isotropic
+type Mat32Iso <: MaternIso
     ℓ::Float64       # Length scale 
     σ2::Float64      # Signal std
     Mat32Iso(ll::Float64, lσ::Float64) = new(exp(ll),exp(2*lσ))
@@ -27,27 +27,4 @@ num_params(mat::Mat32Iso) = 2
 metric(mat::Mat32Iso) = Euclidean()
 cov(mat::Mat32Iso, r::Float64) = mat.σ2*(1+sqrt(3)*r/mat.ℓ)*exp(-sqrt(3)*r/mat.ℓ)
 
-function grad_kern(mat::Mat32Iso, x::Vector{Float64}, y::Vector{Float64})
-    r = distance(mat,x,y)
-    exp_r = exp(-sqrt(3)*r/mat.ℓ)
-
-    g1= mat.σ2*(sqrt(3)*r/mat.ℓ)^2*exp_r       #dK_d(log ℓ)
-    g2 = 2.0*mat.σ2*(1+sqrt(3)*r/mat.ℓ)*exp_r  #dK_d(log σ)
-    return [g1,g2]
-end    
-
-
-function grad_stack!(stack::AbstractArray, mat::Mat32Iso, X::Matrix{Float64}, data::IsotropicData)
-    nobsv = size(X,2)
-    R = distance(mat, X, data)
-    exp_R = exp(-sqrt(3)*R/mat.ℓ)
-
-    for i in 1:nobsv, j in 1:i
-        @inbounds stack[i,j,1] = mat.σ2*(sqrt(3)*R[i,j]/mat.ℓ)^2*exp_R[i,j]       # dK_dℓ
-        @inbounds stack[j,i,1] = stack[i,j,1] 
-        @inbounds stack[i,j,2] = 2.0 *mat.σ2*(1+sqrt(3)*R[i,j]/mat.ℓ)*exp_R[i,j]  # dK_dσ
-        @inbounds stack[j,i,2] = stack[i,j,2] 
-    end
-    
-    return stack
-end
+@inline dk_dll(mat::Mat32Iso, r::Float64) = mat.σ2*(sqrt(3)*r/mat.ℓ)^2*exp(-sqrt(3)*r/mat.ℓ)

--- a/src/kernels/mat52_ard.jl
+++ b/src/kernels/mat52_ard.jl
@@ -9,46 +9,24 @@ k(x,x') = σ²(1+√3*d/L + 5d²/3L²)exp(-√5*d/L), where d = |x-x'| and L = d
 * `ll::Vector{Float64}`: Log of the length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
-type Mat52Ard <: StationaryARD
-    ℓ2::Vector{Float64}   # Log of Length scale 
+type Mat52Ard <: MaternARD
+    iℓ2::Vector{Float64}   # Log of Length scale 
     σ2::Float64           # Log of signal std
-    Mat52Ard(ll::Vector{Float64}, lσ::Float64) = new(exp(2.0*ll), exp(2.0*lσ))
+    Mat52Ard(ll::Vector{Float64}, lσ::Float64) = new(exp(-2.0*ll), exp(2.0*lσ))
 end
 
 function set_params!(mat::Mat52Ard, hyp::Vector{Float64})
     length(hyp) == num_params(mat) || throw(ArgumentError("Mat52 kernel only has $(num_params(mat)) parameters"))
-    d = length(mat.ℓ2)
-    mat.ℓ2 = exp(2.0*hyp[1:d])
+    d = length(mat.iℓ2)
+    mat.iℓ2 = exp(-2.0*hyp[1:d])
     mat.σ2 = exp(2.0*hyp[d+1])
 end
 
-get_params(mat::Mat52Ard) = [log(mat.ℓ2)/2.0; log(mat.σ2)/2.0]
-get_param_names(mat::Mat52Ard) = [get_param_names(mat.ℓ2, :ll); :lσ]
-num_params(mat::Mat52Ard) = length(mat.ℓ2) + 1
+get_params(mat::Mat52Ard) = [-log(mat.iℓ2)/2.0; log(mat.σ2)/2.0]
+get_param_names(mat::Mat52Ard) = [get_param_names(mat.iℓ2, :ll); :lσ]
+num_params(mat::Mat52Ard) = length(mat.iℓ2) + 1
 
-metric(mat::Mat52Ard) = WeightedEuclidean(1.0./(mat.ℓ2))
+metric(mat::Mat52Ard) = WeightedEuclidean(mat.iℓ2)
 cov(mat::Mat52Ard, r::Float64) = mat.σ2*(1+sqrt(5)*r+5/3*r^2)*exp(-sqrt(5)*r)
 
-function grad_kern(mat::Mat52Ard, x::Vector{Float64}, y::Vector{Float64})
-    #r = distance(mat,x,y)
-    wdiff = (x-y).^2./mat.ℓ2
-    r = sqrt(sum(wdiff))
-    exp_r = exp(-sqrt(5)*r)
-    
-    g1 = mat.σ2*(5/3)*(1+sqrt(5)*r)*exp_r.*wdiff # dK_d(log ℓ)
-    g2 = 2.0*mat.σ2*(1+sqrt(5)*r+(5/3)*r^2)*exp_r  # dK_d(log σ)
-    
-    return [g1; g2]
-end
-
-function grad_stack!(stack::AbstractArray, mat::Mat52Ard, X::Matrix{Float64}, data::StationaryARDData)
-    d = size(X,1)
-    R = distance(mat,X)
-    exp_R = exp(-sqrt(5)*R)
-
-    stack[:,:,d+1] = 2.0*cov(mat, X)
-    part = (5/3) * mat.σ2 .* exp_R .* (1.0 + sqrt(5)*R)
-    broadcast!(*, view(stack, :, :, 1:d), (5/3)*mat.σ2, 1 + sqrt(5)*R, exp_R, data.dist_stack, reshape(1.0./mat.ℓ2, (1,1,d)))
-
-    return stack
-end
+dk_dll(mat::Mat52Ard, r::Float64, wdiffp::Float64) = mat.σ2*(5/3)*(1+sqrt(5)*r)*exp(-sqrt(5)*r).*wdiffp

--- a/src/kernels/mat52_iso.jl
+++ b/src/kernels/mat52_iso.jl
@@ -9,7 +9,7 @@ k(x,x') = σ²(1+√5*d/ℓ + 5d²/3ℓ²)exp(-√5*d/ℓ), where d = |x-x'|
 * `ll::Float64`: Log of the length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
-type Mat52Iso <: Isotropic
+type Mat52Iso <: MaternIso
     ℓ::Float64      # Length scale 
     σ2::Float64     # Signal std
     Mat52Iso(ll::Float64, lσ::Float64) = new(exp(ll), exp(2*lσ))
@@ -26,26 +26,4 @@ num_params(mat::Mat52Iso) = 2
 metric(mat::Mat52Iso) = Euclidean()
 cov(mat::Mat52Iso, r::Float64) = mat.σ2*(1+sqrt(5)*r/mat.ℓ+5*r^2/(3*mat.ℓ^2))*exp(-sqrt(5)*r/mat.ℓ)
 
-function grad_kern(mat::Mat52Iso, x::Vector{Float64}, y::Vector{Float64})
-    r = distance(mat,x,y)
-    exp_r = exp(-sqrt(5)*r/mat.ℓ)
-
-    g1 = mat.σ2*(5*r^2/mat.ℓ^2)*((1+sqrt(5)*r/mat.ℓ)/3)*exp_r   #dK_d(log ℓ)
-    g2 = 2.0*mat.σ2*(1+sqrt(5)*r/mat.ℓ+5*r^2/(3*mat.ℓ^2))*exp_r #dK_d(log σ)
-    return [g1,g2]
-end
-
-function grad_stack!(stack::AbstractArray, mat::Mat52Iso, X::Matrix{Float64}, data::IsotropicData)
-    nobsv = size(X,2)
-    R = distance(mat, X, data)
-    exp_R = exp(-sqrt(5)*R/mat.ℓ)
-
-    for i in 1:nobsv, j in 1:i
-        @inbounds stack[i,j,1] = mat.σ2*(5*R[i,j]^2/mat.ℓ^2)*((1+sqrt(5)*R[i,j]/mat.ℓ)/3)*exp_R[i,j]      # dK_dℓ
-        @inbounds stack[j,i,1] = stack[i,j,1] 
-        @inbounds stack[i,j,2] = 2.0*mat.σ2*(1+sqrt(5)*R[i,j]/mat.ℓ+5*R[i,j]^2/(3*mat.ℓ^2))*exp_R[i,j]   # dK_dσ
-        @inbounds stack[j,i,2] = stack[i,j,2] 
-    end
-    
-    return stack
-end
+@inline dk_dll(mat::Mat52Iso, r::Float64) = mat.σ2*(5*r^2/mat.ℓ^2)*((1+sqrt(5)*r/mat.ℓ)/3)*exp(-sqrt(5)*r/mat.ℓ)

--- a/src/kernels/noise.jl
+++ b/src/kernels/noise.jl
@@ -9,33 +9,28 @@ k(x,x') = σ²δ(x-x'), where δ is a Kronecker delta function and equals 1 iff 
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
 type Noise <: Kernel
-    lσ::Float64      # Log of Signal std
-    Noise(lσ::Float64) = new(lσ)
+    σ2::Float64      # Log of Signal std
+    Noise(lσ::Float64) = new(exp(2.0*lσ))
 end
 
+cov(noise::Noise, sameloc::Bool) = noise.σ2*sameloc
 function cov(noise::Noise, x::Vector{Float64}, y::Vector{Float64})
-    sigma2 = exp(2*noise.lσ)
-    prec   = eps()            #machine precision
-    
-    K =  sigma2*(norm(x-y)<prec)
-    return K
+    return cov(noise, (norm(x-y)<eps()))
 end
 
-get_params(noise::Noise) = Float64[noise.lσ]
+get_params(noise::Noise) = Float64[log(noise.σ2)/2.0]
 get_param_names(noise::Noise) = [:lσ]
 num_params(noise::Noise) = 1
 
 function set_params!(noise::Noise, hyp::Vector{Float64})
     length(hyp) == 1 || throw(ArgumentError("Noise kernel only has one parameter"))
-    noise.lσ = hyp[1]
+    noise.σ2 = exp(2.0*hyp[1])
 end
 
-function grad_kern(noise::Noise, x::Vector{Float64}, y::Vector{Float64})
-    sigma2 = exp(2*noise.lσ)
-    prec   = eps()            #machine precision
-    
-    dK_sigma = 2.0*sigma2*(norm(x-y)<prec)
-    
-    dK_theta = [dK_sigma]
-    return dK_theta
+@inline dk_dlσ(noise::Noise, sameloc=Bool) = 2.0*cov(noise,sameloc)
+@inline function dKij_dθp(noise::Noise, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    return dk_dlσ(noise, norm(X[:,i]-X[:,j])<eps())
+end
+@inline function dKij_dθp(noise::Noise, X::Matrix{Float64}, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(noise, X, i, j, p, dim)
 end

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -11,51 +11,41 @@ k(x,x') = σ²(1+(x-x')ᵀL⁻²(x-x')/2α)^{-α}, where L = diag(ℓ₁,ℓ₂,
 * `lα::Float64`        : Log of shape parameter α
 """ ->
 type RQArd <: StationaryARD
-    ℓ2::Vector{Float64}      # Length scale 
+    iℓ2::Vector{Float64}      # Inverse squared Length scale
     σ2::Float64              # Signal std
     α::Float64               # Shape parameter
-    RQArd(ll::Vector{Float64}, lσ::Float64, lα::Float64) = new(exp(2.0*ll), exp(2.0*lσ), exp(lα))
+    RQArd(ll::Vector{Float64}, lσ::Float64, lα::Float64) = new(exp(-2.0*ll), exp(2.0*lσ), exp(lα))
 end
 
 function set_params!(rq::RQArd, hyp::Vector{Float64})
     length(hyp) == num_params(rq) || throw(ArgumentError("RQArd kernel has $(num_params(rq_ard)) parameters"))
-    d = length(rq.ℓ2)
-    rq.ℓ2 = exp(2.0*hyp[1:d])
+    d = length(rq.iℓ2)
+    rq.iℓ2 = exp(-2.0*hyp[1:d])
     rq.σ2 = exp(2.0*hyp[d+1])
     rq.α = exp(hyp[d+2])
 end
 
-get_params(rq::RQArd) = [log(rq.ℓ2)/2.0; log(rq.σ2)/2.0; log(rq.α)]
-get_param_names(rq::RQArd) = [get_param_names(rq.ℓ2, :ll); :lσ; :lα]
-num_params(rq::RQArd) = length(rq.ℓ2) + 2
+get_params(rq::RQArd) = [-log(rq.iℓ2)/2.0; log(rq.σ2)/2.0; log(rq.α)]
+get_param_names(rq::RQArd) = [get_param_names(rq.iℓ2, :ll); :lσ; :lα]
+num_params(rq::RQArd) = length(rq.iℓ2) + 2
 
-metric(rq::RQArd) = WeightedSqEuclidean(1.0./(rq.ℓ2))
+metric(rq::RQArd) = WeightedSqEuclidean(rq.iℓ2)
 cov(rq::RQArd,r::Float64) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
-    
 
-function grad_kern(rq::RQArd, x::Vector{Float64}, y::Vector{Float64})
-    wdiff = ((x-y).^2)./rq.ℓ2
-    r  = sum(wdiff)
+@inline dk_dll(rq::RQArd, r::Float64, wdiffp::Float64) = rq.σ2*wdiffp*(1.0+0.5*r/rq.α)^(-rq.α-1.0)
+@inline function dk_dlα(rq::RQArd, r::Float64)
     part  = (1+0.5*r/rq.α)
-
-    g1   = rq.σ2*wdiff*part^(-rq.α-1)
-    g2   = 2.0*rq.σ2*part^(-rq.α)
-    g3   = rq.σ2*part^(-rq.α)*(0.5*r/part-rq.α*log(part))
-    return [g1; g2; g3]
+    return rq.σ2*part^(-rq.α)*(0.5*r/part-rq.α*log(part))
 end
-
-function grad_stack!(stack::AbstractArray, rq::RQArd, X::Matrix{Float64}, data::StationaryARDData)
-    d = size(X,1)
-    R = distance(rq, X, data)
-    part  = (1+0.5*R/rq.α)
-    
-    stack[:,:,d+2] = cov(rq, X)
-    ck = view(stack, :, :, d+2)
-    part2 = ck./part
-
-    broadcast!(*, view(stack, :, :, 1:d), rq.σ2, data.dist_stack, reshape(1.0./rq.ℓ2, (1,1,d)), part.^(-rq.α - 1))
-
-    stack[:,:, d+1] = 2.0 * ck
-    stack[:,:, d+2] = ck.*(0.5*R./part-rq.α*log(part))
-    return stack
+@inline function dKij_dθp(rq::RQArd, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    if p <= dim
+        return dk_dll(rq, distij(metric(rq),X,i,j,dim), distijk(metric(rq),X,i,j,p))
+    elseif p==dim+1
+        return dk_dlσ(rq, distij(metric(rq),X,i,j,dim))
+    else
+        return dk_dlα(rq, distij(metric(rq),X,i,j,dim))
+    end
+end
+@inline function dKij_dθp(rq::RQArd, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(rq,X,i,j,p,dim)
 end

--- a/src/kernels/rq_iso.jl
+++ b/src/kernels/rq_iso.jl
@@ -29,18 +29,6 @@ num_params(rq::RQIso) = 3
 metric(rq::RQIso) = SqEuclidean()
 cov(rq::RQIso, r::Float64) = rq.σ2*(1.0+r/(2.0*rq.α*rq.ℓ2))^(-rq.α)
 
-function addcov!(s::AbstractMatrix{Float64}, rq::RQIso, X::Matrix{Float64}, data::IsotropicData)
-    nobsv = size(X, 2)
-    R = distance(rq, X, data)
-    for j in 1:nobsv
-        @inbounds @simd for i in 1:j
-            s[i,j] += cov(rq, R[i,j])
-            s[j,i] = s[i,j]
-        end
-    end
-    return R
-end
-
 @inline dk_dll(rq::RQIso, r::Float64) = rq.σ2*(r/rq.ℓ2)*(1.0+r/(2.0*rq.α*rq.ℓ2))^(-rq.α-1.0) # dK_d(log ℓ)dK_dℓ
 @inline function dk_dlα(rq::RQIso, r::Float64)
     part = (1.0+r/(2.0*rq.α*rq.ℓ2))

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -6,33 +6,33 @@ Constructor for the ARD Squared Exponential kernel (covariance)
 
 k(x,x') = σ²exp(-(x-x')ᵀL⁻²(x-x')/2), where L = diag(ℓ₁,ℓ₂,...)
 # Arguments:
-* `ll::Vector{Float64}`: Log of the length scale ℓ
+* `ll::Vector{Float64}`: Log of the inverse length scale ℓ
 * `lσ::Float64`: Log of the signal standard deviation σ
 """ ->
 type SEArd <: StationaryARD
-    ℓ2::Vector{Float64}      # Log of Length scale
-    σ2::Float64              # Log of Signal std
-    SEArd(ll::Vector{Float64}, lσ::Float64) = new(exp(2.0*ll),exp(2.0*lσ))
+    iℓ2::Vector{Float64}      # Inverse squared Length scale
+    σ2::Float64              # Signal variance
+    SEArd(ll::Vector{Float64}, lσ::Float64) = new(exp(-2.0*ll),exp(2.0*lσ))
 end
 
 function set_params!(se::SEArd, hyp::Vector{Float64})
     length(hyp) == num_params(se) || throw(ArgumentError("SEArd only has $(num_params(se)) parameters"))
-    d = length(se.ℓ2)
-    se.ℓ2 = exp(2.0*hyp[1:d])
+    d = length(se.iℓ2)
+    se.iℓ2 = exp(-2.0*hyp[1:d])
     se.σ2 = exp(2.0*hyp[d+1])
 end
 
-get_params(se::SEArd) = [log(se.ℓ2)/2.0; log(se.σ2)/2.0]
-get_param_names(k::SEArd) = [get_param_names(k.ℓ2, :ll); :lσ]
-num_params(se::SEArd) = length(se.ℓ2) + 1
+get_params(se::SEArd) = [-log(se.iℓ2)/2.0; log(se.σ2)/2.0]
+get_param_names(k::SEArd) = [get_param_names(k.iℓ2, :ll); :lσ]
+num_params(se::SEArd) = length(se.iℓ2) + 1
 
-metric(se::SEArd) = WeightedSqEuclidean(1.0./(se.ℓ2))
+metric(se::SEArd) = WeightedSqEuclidean(se.iℓ2)
 cov(se::SEArd, r::Float64) = se.σ2*exp(-0.5*r)
 
 function grad_kern(se::SEArd, x::Vector{Float64}, y::Vector{Float64})
     r = distance(se, x, y)
     exp_r = exp(-0.5*r)
-    wdiff = ((x-y).^2)./se.ℓ2
+    wdiff = ((x-y).^2).*se.iℓ2
     
     g1   = se.σ2.*wdiff*exp_r   #dK_d(log ℓ)
     g2 = 2.0*se.σ2*exp_r        #dK_d(log σ)
@@ -40,10 +40,16 @@ function grad_kern(se::SEArd, x::Vector{Float64}, y::Vector{Float64})
     return [g1; g2]
 end
 
-function grad_stack!(stack::AbstractArray, se::SEArd, X::Matrix{Float64}, data::StationaryARDData)
-    d = size(X,1)
-    ck = cov(se, X, data)
-    broadcast!(*, view(stack, :, :, 1:d), data.dist_stack, reshape(1.0./se.ℓ2, (1,1,d)), ck)
-    stack[:,:, d+1] = 2.0 * ck
-    return stack
+@inline dk_dll(se::SEArd, r::Float64, wdiffp::Float64) = wdiffp*cov(se,r)
+@inline function dKij_dθp(se::SEArd, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    if p <= dim
+        return dk_dll(se, distij(metric(se),X,i,j,dim), distijk(metric(se),X,i,j,p))
+    elseif p==dim+1
+        return dk_dlσ(se, distij(metric(se),X,i,j,dim))
+    else
+        return NaN
+    end
+end
+@inline function dKij_dθp(se::SEArd, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(se,X,i,j,p,dim)
 end

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -114,8 +114,8 @@ function KernelData(k::StationaryARD, X::Matrix{Float64})
     dim, nobsv = size(X)
     dist_stack = Array(Float64, nobsv, nobsv, dim)
     for d in 1:dim
-        grad_ls = Base.view(dist_stack, :, :, d)
-        pairwise!(grad_ls, SqEuclidean(), Base.view(X, d:d,:))
+        grad_ls = view(dist_stack, :, :, d)
+        pairwise!(grad_ls, SqEuclidean(), view(X, d:d,:))
     end
     StationaryARDData(dist_stack)
 end

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -24,10 +24,41 @@ end
 
 function cov(k::Stationary, X::Matrix{Float64}, data::StationaryData)
     nobsv = size(X, 2)
-    R = distance(k, X, data)
+    R = copy(distance(k, X, data))
     for i in 1:nobsv, j in 1:i
         @inbounds R[i,j] = cov(k, R[i,j])
         @inbounds R[j,i] = R[i,j]
+    end
+    return R
+end
+function cov!(cK::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+    nobsv = size(X, 2)
+    R = distance(k, X, data)
+    for i in 1:nobsv, j in 1:i
+        @inbounds cK[i,j] = cov(k, R[i,j])
+        @inbounds cK[j,i] = cK[i,j]
+    end
+    return cK
+end
+function addcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+    nobsv = size(X, 2)
+    R = distance(k, X, data)
+    for j in 1:nobsv
+        @simd for i in 1:j
+            @inbounds s[i,j] += cov(k, R[i,j])
+            @inbounds s[j,i] = s[i,j]
+        end
+    end
+    return R
+end
+function multcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+    nobsv = size(X, 2)
+    R = distance(k, X, data)
+    for j in 1:nobsv
+        @simd for i in 1:j
+            @inbounds s[i,j] *= cov(k, R[i,j])
+            @inbounds s[j,i] = s[i,j]
+        end
     end
     return R
 end
@@ -43,8 +74,32 @@ end
 function KernelData(k::Isotropic, X::Matrix{Float64})
      IsotropicData(distance(k, X))
 end
+function kernel_data_key(k::Isotropic, X::Matrix{Float64})
+    return Symbol(:IsotropicData_, metric(k))
+end
 
-distance(k::Isotropic, X::Matrix{Float64}, data::IsotropicData) = copy(data.R)
+distance(k::Isotropic, X::Matrix{Float64}, data::IsotropicData) = data.R
+function addcov!(s::AbstractMatrix{Float64}, k::Isotropic, X::Matrix{Float64}, data::IsotropicData)
+    nobsv = size(X, 2)
+    R = distance(k, X, data)
+    for j in 1:nobsv
+        @simd for i in 1:j
+            @inbounds s[i,j] += cov(k, R[i,j])
+            @inbounds s[j,i] = s[i,j]
+        end
+    end
+    return R
+end
+@inline function dKij_dθp(kern::Isotropic,X::Matrix{Float64},i::Int,j::Int,p::Int,dim::Int)
+    return dk_dθp(kern, distij(metric(kern),X,i,j,dim),p)
+end
+@inline function dKij_dθp(kern::Isotropic,X::Matrix{Float64},data::IsotropicData,i::Int,j::Int,p::Int,dim::Int)
+    return dk_dθp(kern, data.R[i,j],p)
+end
+function grad_kern(kern::Isotropic, x::Vector{Float64}, y::Vector{Float64})
+    dist=distance(kern,x,y)
+    return [dk_dθp(kern,dist,k) for k in 1:num_params(kern)]
+end
 
 # StationaryARD Kernels
 
@@ -56,14 +111,15 @@ end
 
 # May need to customized in subtypes
 function KernelData(k::StationaryARD, X::Matrix{Float64})
-    d, nobsv = size(X)
-    dist_stack = Array(Float64, nobsv, nobsv, d)
-    for i in 1:d
-        grad_ls = view(dist_stack, :, :, i)
-        pairwise!(grad_ls, SqEuclidean(), X[i,:])
+    dim, nobsv = size(X)
+    dist_stack = Array(Float64, nobsv, nobsv, dim)
+    for d in 1:dim
+        grad_ls = Base.view(dist_stack, :, :, d)
+        pairwise!(grad_ls, SqEuclidean(), Base.view(X, d:d,:))
     end
     StationaryARDData(dist_stack)
 end
+kernel_data_key(k::StationaryARD, X::Matrix{Float64}) = Symbol(:StationaryARDData, metric(k))
 
 function distance(k::StationaryARD, X::Matrix{Float64}, data::StationaryARDData)
     ### This commented section is slower than recalculating the distance from scratch...
@@ -73,3 +129,36 @@ function distance(k::StationaryARD, X::Matrix{Float64}, data::StationaryARDData)
     # return reshape(sum(weighted, 3), (nobsv, nobsv))
     return pairwise(metric(k), X)
 end
+@inline distijk(dist::SqEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
+@inline function distij(dist::SqEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+    s = 0.0
+    @inbounds @simd for k in 1:dim
+        s += distijk(dist,X,i,j,k)
+    end
+    return s
+end
+@inline distijk(dist::Euclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
+@inline function distij(dist::Euclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+    s = 0.0
+    @inbounds @simd for k in 1:dim
+        s += distijk(dist,X,i,j,k)
+    end
+    return √s
+end
+@inline distijk(dist::WeightedSqEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
+@inline function distij(dist::WeightedSqEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+    s = 0.0
+    @inbounds @simd for k in 1:dim
+        s += distijk(dist,X,i,j,k)
+    end
+    return s
+end
+@inline dist2ijk(dist::WeightedEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
+@inline function distij(dist::WeightedEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+    s = 0.0
+    @inbounds @simd for k in 1:dim
+        s += dist2ijk(dist,X,i,j,k)
+    end
+    return √s
+end
+dk_dlσ(k::Stationary, r::Float64) = 2.0*cov(k,r)

--- a/src/kernels/sum_kernel.jl
+++ b/src/kernels/sum_kernel.jl
@@ -10,6 +10,25 @@ type SumKernel <: Kernel
     end
 end
 
+type SumData <: KernelData
+    datadict::Dict{Symbol, KernelData}
+    keys::Vector{Symbol}
+end
+
+function KernelData(sumkern::SumKernel, X::Matrix{Float64})
+    datadict = Dict{Symbol, KernelData}()
+    datakeys = Symbol[]
+    for k in sumkern.kerns
+        data_type = kernel_data_key(k, X)
+        if !haskey(datadict, data_type)
+            datadict[data_type] = KernelData(k, X)
+        end
+        push!(datakeys, data_type)
+    end
+    SumData(datadict, datakeys)
+end
+kernel_data_key(sumkern::SumKernel, X::Matrix{Float64}) = :SumData
+
 function show(io::IO, sumkern::SumKernel, depth::Int = 0)
     pad = repeat(" ", 2 * depth)
     println(io, "$(pad)Type: $(typeof(sumkern))")
@@ -26,33 +45,17 @@ function cov(sumkern::SumKernel, x::Vector{Float64}, y::Vector{Float64})
     return s
 end
 
-# This slows down cov...
-
-## function cov(X::Matrix{Float64}, sumkern::SumKernel)
-##     d, nobsv = size(X)
-##     s = zeros(nobsv, nobsv)
-##     for k in sumkern.kerns
-##         BLAS.axpy!(nobsv*nobsv, 1.0, cov(X,k), 1, s, 1)
-##         #s += cov(X, k)
-##     end
-##     return s
-## end
-
-## function add_matrices!(X::AbstractMatrix, Y::AbstractMatrix)
-##     m,n = size(X)
-##     for i in 1:m, j in 1:n
-##         X[i,j] += Y[i,j]
-##     end
-## end
-
-function cov(sumkern::SumKernel, X::Matrix{Float64})
-    d, nobsv = size(X)
-    s = zeros(nobsv, nobsv)
-    for k in sumkern.kerns
-        #add_matrices!(s, cov(X,k))
-        s[:,:] = s + cov(k, X)
+function cov!(s::Matrix{Float64}, sumkern::SumKernel, X::Matrix{Float64}, data::SumData)
+    s[:,:] = 0.0
+    for (ikern,kern) in enumerate(sumkern.kerns)
+        addcov!(s, kern, X, data.datadict[data.keys[ikern]])
     end
     return s
+end
+function cov(sumkern::SumKernel, X::Matrix{Float64}, data::SumData)
+    d, nobsv = size(X)
+    s = zeros(nobsv, nobsv)
+    cov!(s, sumkern, X, data)
 end
     
 function get_params(sumkern::SumKernel)
@@ -80,7 +83,7 @@ function set_params!(sumkern::SumKernel, hyp::Vector{Float64})
         np = num_params(k)
         set_params!(k, hyp[i:(i+np-1)])
         i += np
-   p end
+    end
 end
 
 function grad_kern(sumkern::SumKernel, x::Vector{Float64}, y::Vector{Float64})
@@ -91,14 +94,36 @@ function grad_kern(sumkern::SumKernel, x::Vector{Float64}, y::Vector{Float64})
     dk
 end
 
-function grad_stack!(stack::AbstractArray, X::Matrix{Float64}, sumkern::SumKernel)
-    s = 1
-    for kern in sumkern.kerns
-        np = num_params(kern)
-        grad_stack!(view(stack,:, :, s:(s+np-1)), X, kern)
+@inline function dKij_dθp(sumkern::SumKernel, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+    s=0
+    for k in sumkern.kerns
+        np = num_params(k)
+        if p<=np+s
+            return dKij_dθp(k, X, i,j,p-s,dim)
+        end
         s += np
     end
-    return stack
+end
+@inline function dKij_dθp(sumkern::SumKernel, X::Matrix{Float64}, data::SumData, i::Int, j::Int, p::Int, dim::Int)
+    s=0
+    for (ikern,kern) in enumerate(sumkern.kerns)
+        np = num_params(kern)
+        if p<=np+s
+            return dKij_dθp(kern, X, data.datadict[data.keys[ikern]],i,j,p-s,dim)
+        end
+        s += np
+    end
+end
+function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X::Matrix{Float64}, data::KernelData, p::Int)
+    s=0
+    for (ikern,kern) in enumerate(sumkern.kerns)
+        np = num_params(kern)
+        if p<=np+s
+            return grad_slice!(dK, kern, X, data.datadict[data.keys[ikern]],p-s)
+        end
+        s += np
+    end
+    return dK
 end
         
 # Addition operators

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -12,25 +12,65 @@ A function for optimising the GP hyperparameters based on type II maximum likeli
 # Return:
 * `::Optim.MultivariateOptimizationResults{Float64,1}`: optimization results object
 """ ->
-function optimize!(gp::GP; noise::Bool=true, mean::Bool=true, kern::Bool=true, method::Optim.Optimizer=ConjugateGradient(), kwargs...)
+function optimize!(gp::GP; noise::Bool=true, mean::Bool=true, kern::Bool=true,
+                    method=ConjugateGradient(), kwargs...)
+    func = get_optim_target(gp, noise=noise, mean=mean, kern=kern)
+    init = get_params(gp;  noise=noise, mean=mean, kern=kern)  # Initial hyperparameter values
+    results=optimize(func,init; method=method, kwargs...)                     # Run optimizer
+    set_params!(gp, results.minimum, noise=noise,mean=mean,kern=kern)
+    update_mll!!(gp)
+    return results
+end
+
+function get_optim_target(gp::GP; noise::Bool=true, mean::Bool=true, kern::Bool=true)
+    Kgrad_buffer = Array(Float64, gp.nobsv, gp.nobsv)
+    ααinvcKI_buffer = Array(Float64, gp.nobsv, gp.nobsv)
     function mll(hyp::Vector{Float64})
-        set_params!(gp, hyp; noise=noise, mean=mean, kern=kern)
-        update_mll!(gp)
-        return -gp.mLL
+        try
+            set_params!(gp, hyp; noise=noise, mean=mean, kern=kern)
+            update_mll!!(gp)
+            return -gp.mLL
+        catch err
+             if !all(isfinite(hyp))
+                println(err)
+                return Inf
+            elseif isa(err, ArgumentError)
+                println(err)
+                return Inf
+            elseif isa(err, Base.LinAlg.PosDefException)
+                println(err)
+                return Inf
+            else
+                throw(err)
+            end
+        end        
+    end
+
+    function mll_and_dmll!(hyp::Vector{Float64}, grad::Vector{Float64})
+        try
+            set_params!(gp, hyp; noise=noise, mean=mean, kern=kern)
+            update_mll_and_dmll!(gp, Kgrad_buffer, ααinvcKI_buffer; noise=noise, mean=mean, kern=kern)
+            grad[:] = -gp.dmLL
+            return -gp.mLL
+        catch err
+             if !all(isfinite(hyp))
+                println(err)
+                return Inf
+            elseif isa(err, ArgumentError)
+                println(err)
+                return Inf
+            elseif isa(err, Base.LinAlg.PosDefException)
+                println(err)
+                return Inf
+            else
+                throw(err)
+            end
+        end 
     end
     function dmll!(hyp::Vector{Float64}, grad::Vector{Float64})
-        set_params!(gp, hyp; noise=noise, mean=mean, kern=kern)
-        update_mll_and_dmll!(gp; noise=noise, mean=mean, kern=kern)
-        grad[:] = -gp.dmLL
-    end
-    function mll_and_dmll!(hyp::Vector{Float64}, grad::Vector{Float64})
-        set_params!(gp, hyp; noise=noise, mean=mean, kern=kern)
-        update_mll_and_dmll!(gp; noise=noise, mean=mean, kern=kern)
-        grad[:] = -gp.dmLL
-        return -gp.mLL
+        mll_and_dmll!(hyp::Vector{Float64}, grad::Vector{Float64})
     end
 
     func = DifferentiableFunction(mll, dmll!, mll_and_dmll!)
-    init = get_params(gp;  noise=noise, mean=mean, kern=kern)  # Initial hyperparameter values
-    optimize(func, init, method, kwargs...)                    # Run optimizer
+    return func
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,31 @@
 @doc """
 # Description
+ Populates D matrix applying a function to each pair of columns of input matrices.
+     
+# Arguments:
+* `D::Matrix{Float64}`  : Output matrix
+* `X::Matrix{Float64}`  : Input matrix
+* `Y::Matrix{Float64}`  : Input matrix (optional)
+* `f::Function`          : Testing function. In this case a function of distance between X and Y
+    
+# Return:
+* `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = f(X[:,i], Y[:,j])`
+""" ->
+function map_column_pairs!(D::Matrix{Float64}, f::Function, X::Matrix{Float64}, Y::Matrix{Float64})
+    dim, nobs1 = size(X)
+    nobs2 = size(Y,2)
+    dim == size(Y,1) || throw(ArgumentError("Input observation matrices must have consistent dimensions"))
+    size(D,1) == nobs1 || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)", 
+                                                       size(D,1), nobs1)))
+    size(D,2) == nobs2 || throw(ArgumentError(@sprintf("D has %d columns, while Y has %d columns (should be same)", 
+                                                       size(D,2), nobs2)))
+    for i in 1:nobs1, j in 1:nobs2
+        @inbounds D[i,j] = f(X[:,i], Y[:,j])
+    end
+    return D
+end
+@doc """
+# Description
  Creates a matrix by applying a function to each pair of columns of input matrices.
      
 # Arguments:
@@ -11,12 +37,37 @@
 * `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = f(X[:,i], Y[:,j])`
 """ ->
 function map_column_pairs(f::Function, X::Matrix{Float64}, Y::Matrix{Float64})
-    dim, nobs1 = size(X)
+    nobs1 = size(X,2)
     nobs2 = size(Y,2)
-    dim == size(Y,1) || throw(ArgumentError("Input observation matrices must have consistent dimensions"))
     D= Array(Float64, nobs1, nobs2)
-    for i in 1:nobs1, j in 1:nobs2
-        @inbounds D[i,j] = f(X[:,i], Y[:,j])
+    map_column_pairs!(D, f, X, Y)
+    return D
+end
+
+@doc """
+# Description
+Populates D matrix by applying a function to each pair of columns of an input matrix.
+
+# Arguments
+* `D::AbstractMatrix{Float64}`  : Output matrix
+* `X::Matrix{Float64}`: matrix of observations (each column is an observation)
+* `d::Function`: function specifying covariance between two points
+
+# Return:
+* `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = d(X[:,i], X[:,j])`
+
+""" ->
+function map_column_pairs!(D::AbstractMatrix{Float64}, f::Function, X::Matrix{Float64})
+    dim, nobsv = size(X)
+    size(D,1) == nobsv || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)", 
+                                                       size(D,1), nobsv)))
+    size(D,2) == nobsv || throw(ArgumentError(@sprintf("D has %d columns, while X has %d columns (should be same)", 
+                                                       size(D,2), nobsv)))
+    for i in 1:nobsv
+        for j in 1:i
+            @inbounds D[i,j] = f(X[:,i], X[:,j])
+            if i != j; @inbounds D[j,i] = D[i,j]; end;
+        end
     end
     return D
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,8 @@ include("test_utils.jl")
 println("Running test_GP.jl...")
 include("test_GP.jl")
 
+println("Running test_optim.jl...")
+include("test_optim.jl")
+
 println("Running test_kernels.jl...")
 include("test_kernels.jl")

--- a/test/test_kernels.jl
+++ b/test/test_kernels.jl
@@ -1,97 +1,160 @@
 using GaussianProcesses, Base.Test
-using GaussianProcesses: get_params, get_param_names, num_params, KernelData, EmptyData
+using GaussianProcesses: get_params, get_param_names, KernelData, EmptyData
+using GaussianProcesses: set_params!, num_params, grad_stack!
+using GaussianProcesses: GP, MeanConst, update_mll!, update_mll_and_dmll!
+import Calculus
 
 function test_cov(kern::Kernel, X::Matrix{Float64})
     spec = GaussianProcesses.cov(kern, X)
     gen = invoke(GaussianProcesses.cov, (Kernel, Matrix{Float64}), kern, X)
     @test_approx_eq spec gen
+    dim,n=size(X)
+    i = rand(1:n)
+    j = rand(1:n)
+    cK_ij = GaussianProcesses.cov(kern, X[:,i], X[:,j])
+    @test_approx_eq cK_ij spec[i,j]
+    cK_added = zeros(n,n)
+    GaussianProcesses.addcov!(cK_added, kern, X)
+    @test_approx_eq spec cK_added
+    cK_added[:,:] = 0.0
+    GaussianProcesses.addcov!(cK_added, kern, X, KernelData(kern,X))
+    @test_approx_eq spec cK_added
+    cK_prod = ones(n,n)
+    GaussianProcesses.multcov!(cK_prod, kern, X)
+    @test_approx_eq spec cK_prod
+    cK_prod[:,:] = 1.0
+    GaussianProcesses.multcov!(cK_prod, kern, X, KernelData(kern,X))
+    @test_approx_eq spec cK_prod
 end
 
 function test_grad_stack(kern::Kernel, X::Matrix{Float64})
-    n = GaussianProcesses.num_params(kern)
+    n = num_params(kern)
     data = KernelData(kern, X)
     d, nobsv = size(X)
     stack1 = Array(Float64, nobsv, nobsv, n)
     stack2 = Array(Float64, nobsv, nobsv, n)
     
-    GaussianProcesses.grad_stack!(stack1, kern, X, data)
-    invoke(GaussianProcesses.grad_stack!, (AbstractArray, Kernel, Matrix{Float64}, EmptyData), stack2, kern, X, EmptyData())
+    grad_stack!(stack1, kern, X, data)
+    invoke(grad_stack!, (AbstractArray, Kernel, Matrix{Float64}, EmptyData), stack2, kern, X, EmptyData())
     @test_approx_eq stack1 stack2
 end
 
-function test_Kernel(kern::Kernel, x::Matrix{Float64})
+function test_gradient(kern::Kernel, X::Matrix{Float64})
+    init_params = get_params(kern)
+    data = KernelData(kern, X)
+    nobsv = size(X,2)
+    function f(hyp)
+        set_params!(kern, hyp)
+        s = sum(cov(kern, X))
+        return s
+    end
+    stack = Array(Float64, nobsv, nobsv, num_params(kern))
+    grad_stack!(stack, kern, X, data)
+    theor_grad = vec(sum(stack, [1,2]))
+    numer_grad = Calculus.gradient(f, init_params)
+    for i in 1:length(theor_grad)
+        @assert isapprox(theor_grad[i], numer_grad[i], rtol=1e-1, atol=1e-2) string(
+            theor_grad, " != ", numer_grad, " at index ", i
+            )
+    end
+end
+
+function test_dmLL(kern::Kernel, X::Matrix{Float64}, y::Vector{Float64})
+    gp = GP(X,y,MeanConst(0.0), kern, -3.0)
+    init_params = get_params(gp)
+    nobsv = size(X,2)
+    function f(hyp)
+        set_params!(gp, hyp)
+        update_mll!(gp)
+        return gp.mLL
+    end
+    update_mll_and_dmll!(gp)
+    theor_grad = copy(gp.dmLL)
+    numer_grad = Calculus.gradient(f, init_params)
+    set_params!(gp, init_params)
+    for i in 1:length(theor_grad)
+        @assert isapprox(theor_grad[i], numer_grad[i], rtol=1e-3, atol=1e-3) string(
+            theor_grad, " != ", numer_grad, " at index ", i
+            )
+    end
+end
+
+function test_Kernel(kern::Kernel, x::Matrix{Float64}, y::Vector{Float64})
     t = typeof(kern)
     println("\tTesting $(t)...")
     @assert length(get_param_names(kern)) == length(get_params(kern)) == num_params(kern)
     test_cov(kern, x)
     test_grad_stack(kern, x)
+    test_gradient(kern, x)
+    test_dmLL(kern, x, y)
 end
     
 d, n = 2, 4
 ll = rand(d)
 x = 2π * rand(d, n)
+y = randn(n)
 
 # Isotropic kernels
 
 se = SEIso(1.0, 1.0)
-test_Kernel(se, x)
+test_Kernel(se, x, y)
 
 mat12 = Mat12Iso(1.0,1.0)
-test_Kernel(mat12, x)
+test_Kernel(mat12, x, y)
 
 mat32 = Mat32Iso(1.0,1.0)
-test_Kernel(mat32, x)
+test_Kernel(mat32, x, y)
 
 mat52 = Mat52Iso(1.0,1.0)
-test_Kernel(mat52, x)
+test_Kernel(mat52, x, y)
 
 rq = RQIso(1.0, 1.0, 1.0)
-test_Kernel(rq, x)
+test_Kernel(rq, x, y)
 
 peri = Periodic(1.0, 1.0, 2π)
-test_Kernel(peri, x)
+test_Kernel(peri, x, y)
 
 # Non-isotropic
 
 lin = Lin(1.0)
-test_Kernel(lin, x)
+test_Kernel(lin, x, y)
 
 poly = Poly(0.0, 0.0, 2)
-test_Kernel(poly, x)
+test_Kernel(poly, x, y)
 
 noise = Noise(1.0)
-test_Kernel(noise, x)
+test_Kernel(noise, x, y)
 
 # ARD kernels
 
 se_ard = SEArd(ll, 1.0)
-test_Kernel(se_ard, x)
+test_Kernel(se_ard, x, y)
 
 mat12_ard = Mat12Ard(ll, 1.0)
-test_Kernel(mat12_ard, x)
+test_Kernel(mat12_ard, x, y)
 
 mat32_ard = Mat32Ard(ll, 1.0)
-test_Kernel(mat32_ard, x)
+test_Kernel(mat32_ard, x, y)
 
 mat52_ard = Mat52Ard(ll, 1.0)
-test_Kernel(mat52_ard, x)
+test_Kernel(mat52_ard, x, y)
 
 rq_ard=RQArd(ll, 0.0, 2.0)
-test_Kernel(rq_ard, x)
+test_Kernel(rq_ard, x, y)
 
 lin_ard = LinArd(ll)
-test_Kernel(lin_ard, x)
+test_Kernel(lin_ard, x, y)
 
 # Composite kernels
 
 sum_kern = se + mat12
-test_Kernel(sum_kern, x)
+test_Kernel(sum_kern, x, y)
 
 sum_kern_3 = sum_kern + lin
-test_Kernel(sum_kern_3, x)
+test_Kernel(sum_kern_3, x, y)
 
 prod_kern = se * mat12
-test_Kernel(prod_kern, x)
+test_Kernel(prod_kern, x, y)
 
 prod_kern_3 = prod_kern * lin
-test_Kernel(prod_kern_3, x)
+test_Kernel(prod_kern_3, x, y)

--- a/test/test_optim.jl
+++ b/test/test_optim.jl
@@ -1,0 +1,19 @@
+using GaussianProcesses
+
+d, n = 2, 20
+ll = rand(d)
+x = 2π * rand(d, n)
+y = randn(n) + 0.5
+
+""" Not much of a test really... just checks that it doesn't crash
+    and that the final mll is better that the initial value
+"""
+function test_optim(kern::Kernel, X::Matrix{Float64}, y::Vector{Float64})
+	gp = GP(X,y,MeanConst(0.0), kern, -3.0)
+	init_mLL = gp.mLL
+	optimize!(gp)
+	@assert gp.mLL > init_mLL
+end
+
+se = SEIso(1.0, 1.0)
+test_optim(se, x, y)


### PR DESCRIPTION
revamp gradients implementations to avoid unnecessary memory allocations, fix some gradients along the way, add some tests, and make things generally faster

I'm dealing with some relatively large dataset (N>10000 or so), and very quickly started running out of RAM when optimizing hyperparameters. I've modified the way kernel gradients are obtained, to reduce the number of memory allocations that are necessary.

Along the way I found a few gradients that were wrong (I've added tests so they should all be correct now), and generally rewrote a lot of functions to make them faster.

Incidentally, the new gradient functions make it easy to get the derivative of the kernel with respect to a single parameter (with the grad_slice function), which should make #33 easier to achieve.