### PR TITLE
Pull request/9d7fe8ca

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Optim 0.5-
 PDMats 0.3-
 Distances 0.2-

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -9,7 +9,7 @@ import Base: rand, rand!, mean, cov, push!
 # Functions that should be available to package
 # users should be explicitly exported here
 
-export GP, predict, SumKernel, ProdKernel, Noise, Kernel, SE, SEIso, SEArd, Periodic, Poly, RQ, RQIso, RQArd, Lin, LinIso, LinArd, Mat, Mat12Iso, Mat12Ard, Mat32Iso, Mat32Ard, Mat52Iso, Mat52Ard, MeanZero, MeanConst, MeanLin, MeanPoly, SumMean, ProdMean, optimize!
+export GP, predict, SumKernel, ProdKernel, Masked, Noise, Kernel, SE, SEIso, SEArd, Periodic, FixedPeriodic, Poly, RQ, RQIso, RQArd, Lin, LinIso, LinArd, Mat, Mat12Iso, Mat12Ard, Mat32Iso, Mat32Ard, Mat52Iso, Mat52Ard, MeanZero, MeanConst, MeanLin, MeanPoly, SumMean, ProdMean, optimize!
 
 typealias MatF64 AbstractMatrix{Float64}
 typealias VecF64 AbstractVector{Float64}

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -11,6 +11,9 @@ import Base: rand, rand!, mean, cov, push!
 
 export GP, predict, SumKernel, ProdKernel, Noise, Kernel, SE, SEIso, SEArd, Periodic, Poly, RQ, RQIso, RQArd, Lin, LinIso, LinArd, Mat, Mat12Iso, Mat12Ard, Mat32Iso, Mat32Ard, Mat52Iso, Mat52Ard, MeanZero, MeanConst, MeanLin, MeanPoly, SumMean, ProdMean, optimize!
 
+typealias MatF64 AbstractMatrix{Float64}
+typealias VecF64 AbstractVector{Float64}
+
 # all package code should be included here
 include("means/meanFunctions.jl")
 include("kernels/kernels.jl")

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -194,3 +194,4 @@ include("noise.jl")             # White noise covariance function
 # Composite kernels
 include("sum_kernel.jl")        # Sum of kernels
 include("prod_kernel.jl")       # Product of kernels
+include("masked_kernel.jl")     # Masked kernels (apply to subset of X dims)

--- a/src/kernels/lin.jl
+++ b/src/kernels/lin.jl
@@ -1,7 +1,7 @@
 # Linear covariance function
 
-@inline dotijp(X::Matrix{Float64}, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
-@inline function dotij(X::Matrix, i::Int, j::Int, dim::Int)
+@inline dotijp{M<:MatF64}(X::M, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
+@inline function dotij{M<:MatF64}(X::M, i::Int, j::Int, dim::Int)
 	s=zero(eltype(X))
 	@inbounds @simd for p in 1:dim
 		s+=dotijp(X,i,j,p)

--- a/src/kernels/masked_kernel.jl
+++ b/src/kernels/masked_kernel.jl
@@ -1,0 +1,80 @@
+""" 
+# Description
+A `Masked` kernel type is a wrapper for kernels so
+that they are only applied along certain dimensions of `X`.
+This is similar to the `active_dims` kernel attribute in the python GPy 
+package and to the `covMask` function in the matlab gpml package.
+
+The implementation is very simple: any function of the kernel
+that takes an `X::Matrix` input is delegated to the wrapped 
+kernel along with a view of the X matrix that only includes
+the active dimensions.
+
+# Arguments
+* `kern::Kernel`: The wrapper kernel
+* `active_dims::Vector{Int}`: A vector of dimensions on which the kernel applies
+"""
+type Masked{K<:Kernel} <: Kernel
+    kern::K
+    active_dims::Vector{Int}
+end
+
+function cov{K<:Kernel,M1<:MatF64,M2<:MatF64}(masked::Masked{K}, x1::M1, x2::M2)
+    return cov(masked.kern, view(x1,masked.active_dims,:), view(x2,masked.active_dims,:))
+end
+function cov{K<:Kernel,V1<:VecF64,V2<:VecF64}(masked::Masked{K}, x1::V1, x2::V2)
+    return cov(masked.kern, view(x1,masked.active_dims), view(x2,masked.active_dims))
+end
+function cov{K<:Kernel,M<:MatF64}(masked::Masked{K}, X::M, data::KernelData)
+    return cov(masked.kern, view(X,masked.active_dims,:), data)
+end
+function cov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::KernelData)
+    return cov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function addcov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::KernelData)
+    return addcov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function multcov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::KernelData)
+    return multcov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function KernelData{K<:Kernel,M<:MatF64}(masked::Masked{K}, X::M)
+    return KernelData(masked.kern, view(X,masked.active_dims,:))
+end
+function kernel_data_key{K<:Kernel,M<:MatF64}(masked::Masked{K}, X::M)
+    k = kernel_data_key(masked.kern, view(X,masked.active_dims,:))
+    return Symbol(k, "_active=", masked.active_dims)
+end
+
+
+get_params{K<:Kernel}(masked::Masked{K}) = get_params(masked.kern)
+get_param_names{K<:Kernel}(masked::Masked{K}) = get_param_names(masked.kern)
+num_params{K<:Kernel}(masked::Masked{K}) = num_params(masked.kern)
+set_params!{K<:Kernel}(masked::Masked{K}, hyp) = set_params!(masked.kern, hyp)
+function grad_slice!{K<:Kernel, M1<:MatF64, M2<:MatF64}(
+    dK::M1, masked::Masked{K}, X::M2, data::KernelData, iparam::Int)
+    return grad_slice!(dK, masked.kern, view(X,masked.active_dims,:), data, iparam)
+end
+
+# with EmptyData
+function cov{K<:Kernel,M<:MatF64}(masked::Masked{K}, X::M, data::EmptyData)
+    return cov(masked.kern, view(X,masked.active_dims,:), data)
+end
+function cov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::EmptyData)
+    return cov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function addcov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::EmptyData)
+    return addcov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function multcov!{K<:Kernel,M1<:MatF64, M2<:MatF64}(
+    s::M1, masked::Masked{K}, X::M2, data::EmptyData)
+    return multcov!(s, masked.kern, view(X,masked.active_dims,:), data)
+end
+function grad_slice!{K<:Kernel, M1<:MatF64, M2<:MatF64}(
+    dK::M1, masked::Masked{K}, X::M2, data::EmptyData, iparam::Int)
+    return grad_slice!(dK, masked.kern, view(X,masked.active_dims,:), data, iparam)
+end

--- a/src/kernels/mat.jl
+++ b/src/kernels/mat.jl
@@ -2,7 +2,7 @@
 abstract MaternIso <: Isotropic
 abstract MaternARD <: StationaryARD
 
-@inline function dKij_dθp(mat::MaternARD, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(mat::MaternARD, X::M, i::Int, j::Int, p::Int, dim::Int)
     r=distij(metric(mat),X,i,j,dim)
     if p <= dim
         wdiffp=dist2ijk(metric(mat),X,i,j,p)
@@ -13,7 +13,7 @@ abstract MaternARD <: StationaryARD
         return NaN
     end
 end
-@inline function dKij_dθp(mat::MaternARD, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(mat::MaternARD, X::M, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(mat,X,i,j,p,dim)
 end
 

--- a/src/kernels/noise.jl
+++ b/src/kernels/noise.jl
@@ -14,7 +14,7 @@ type Noise <: Kernel
 end
 
 cov(noise::Noise, sameloc::Bool) = noise.σ2*sameloc
-function cov(noise::Noise, x::Vector{Float64}, y::Vector{Float64})
+function cov{V1<:VecF64,V2<:VecF64}(noise::Noise, x::V1, y::V2)
     return cov(noise, (norm(x-y)<eps()))
 end
 
@@ -28,9 +28,9 @@ function set_params!(noise::Noise, hyp::Vector{Float64})
 end
 
 @inline dk_dlσ(noise::Noise, sameloc=Bool) = 2.0*cov(noise,sameloc)
-@inline function dKij_dθp(noise::Noise, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(noise::Noise, X::M, i::Int, j::Int, p::Int, dim::Int)
     return dk_dlσ(noise, norm(X[:,i]-X[:,j])<eps())
 end
-@inline function dKij_dθp(noise::Noise, X::Matrix{Float64}, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(noise::Noise, X::M, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(noise, X, i, j, p, dim)
 end

--- a/src/kernels/periodic.jl
+++ b/src/kernels/periodic.jl
@@ -45,19 +45,3 @@ cov(pe::Periodic, r::Float64) = pe.σ2*exp(-2.0/pe.ℓ2*sin(π*r/pe.p)^2)
     end
 end
 
-function grad_stack!(stack::AbstractArray,  pe::Periodic, X::Matrix{Float64}, data::IsotropicData)
-    d, nobsv = size(X)
-    R = distance(pe, X, data)
-    
-    for i in 1:nobsv, j in 1:i
-        @inbounds stack[i,j,1] = 4.0*pe.σ2*(sin(π*R[i,j]/pe.p)^2/pe.ℓ2)*exp(-2/pe.ℓ2*sin(π*R[i,j]/pe.p)^2)  # dK_dlogℓ
-        @inbounds stack[j,i,1] = stack[i,j,1]
-        
-        @inbounds stack[i,j,2] = 2.0*pe.σ2*exp(-2/pe.ℓ2*sin(π*R[i,j]/pe.p)^2)        # dK_dlogσ
-        @inbounds stack[j,i,2] = stack[i,j,2]
-        
-        @inbounds stack[i,j,3] = 4.0/pe.ℓ2*pe.σ2*(π*R[i,j]/pe.p)*sin(π*R[i,j]/pe.p)*cos(π*R[i,j]/pe.p)*exp(-2/pe.ℓ2*sin(π*R[i,j]/pe.p)^2)    # dK_dlogp
-        @inbounds stack[j,i,3] = stack[i,j,3]
-    end
-    return stack
-end

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -37,7 +37,7 @@ cov(rq::RQArd,r::Float64) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
     part  = (1+0.5*r/rq.α)
     return rq.σ2*part^(-rq.α)*(0.5*r/part-rq.α*log(part))
 end
-@inline function dKij_dθp(rq::RQArd, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(rq::RQArd, X::M, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
         return dk_dll(rq, distij(metric(rq),X,i,j,dim), distijk(metric(rq),X,i,j,p))
     elseif p==dim+1
@@ -46,6 +46,6 @@ end
         return dk_dlα(rq, distij(metric(rq),X,i,j,dim))
     end
 end
-@inline function dKij_dθp(rq::RQArd, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(rq::RQArd, X::M, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(rq,X,i,j,p,dim)
 end

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -29,19 +29,8 @@ num_params(se::SEArd) = length(se.iℓ2) + 1
 metric(se::SEArd) = WeightedSqEuclidean(se.iℓ2)
 cov(se::SEArd, r::Float64) = se.σ2*exp(-0.5*r)
 
-function grad_kern(se::SEArd, x::Vector{Float64}, y::Vector{Float64})
-    r = distance(se, x, y)
-    exp_r = exp(-0.5*r)
-    wdiff = ((x-y).^2).*se.iℓ2
-    
-    g1   = se.σ2.*wdiff*exp_r   #dK_d(log ℓ)
-    g2 = 2.0*se.σ2*exp_r        #dK_d(log σ)
-    
-    return [g1; g2]
-end
-
 @inline dk_dll(se::SEArd, r::Float64, wdiffp::Float64) = wdiffp*cov(se,r)
-@inline function dKij_dθp(se::SEArd, X::Matrix{Float64}, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(se::SEArd, X::M, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
         return dk_dll(se, distij(metric(se),X,i,j,dim), distijk(metric(se),X,i,j,p))
     elseif p==dim+1
@@ -50,6 +39,6 @@ end
         return NaN
     end
 end
-@inline function dKij_dθp(se::SEArd, X::Matrix{Float64}, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp{M<:MatF64}(se::SEArd, X::M, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(se,X,i,j,p,dim)
 end

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -6,13 +6,13 @@
 abstract Stationary <: Kernel
 abstract StationaryData <: KernelData
 
-distance(k::Stationary, X::Matrix{Float64}) = pairwise(metric(k), X)
-distance(k::Stationary, X::Matrix{Float64}, Y::Matrix{Float64}) = pairwise(metric(k), X, Y)
-distance(k::Stationary, x::Vector{Float64}, y::Vector{Float64}) = evaluate(metric(k), x, y)
+distance{M<:MatF64}(k::Stationary, X::M) = pairwise(metric(k), X)
+distance{M1<:MatF64,M2<:MatF64}(k::Stationary, X::M1, Y::M2) = pairwise(metric(k), X, Y)
+distance{V1<:VecF64,V2<:VecF64}(k::Stationary, x::V1, y::V2) = evaluate(metric(k), x, y)
 
-cov(k::Stationary, x::Vector{Float64}, y::Vector{Float64}) = cov(k, distance(k, x, y))
+cov{V1<:VecF64,V2<:VecF64}(k::Stationary, x::V1, y::V2) = cov(k, distance(k, x, y))
 
-function cov(k::Stationary, x1::Matrix{Float64}, x2::Matrix{Float64})
+function cov{M1<:MatF64,M2<:MatF64}(k::Stationary, x1::M1, x2::M2)
     nobsv1 = size(x1, 2)
     nobsv2 = size(x2, 2)
     R = distance(k, x1, x2)
@@ -22,7 +22,7 @@ function cov(k::Stationary, x1::Matrix{Float64}, x2::Matrix{Float64})
     return R
 end
 
-function cov(k::Stationary, X::Matrix{Float64}, data::StationaryData)
+function cov{M<:MatF64}(k::Stationary, X::M, data::StationaryData)
     nobsv = size(X, 2)
     R = copy(distance(k, X, data))
     for i in 1:nobsv, j in 1:i
@@ -31,7 +31,7 @@ function cov(k::Stationary, X::Matrix{Float64}, data::StationaryData)
     end
     return R
 end
-function cov!(cK::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+function cov!{M<:MatF64}(cK::MatF64, k::Stationary, X::M, data::StationaryData)
     nobsv = size(X, 2)
     R = distance(k, X, data)
     for i in 1:nobsv, j in 1:i
@@ -40,7 +40,7 @@ function cov!(cK::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, da
     end
     return cK
 end
-function addcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+function addcov!{M<:MatF64}(s::MatF64, k::Stationary, X::M, data::StationaryData)
     nobsv = size(X, 2)
     R = distance(k, X, data)
     for j in 1:nobsv
@@ -51,7 +51,7 @@ function addcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, 
     end
     return R
 end
-function multcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64}, data::StationaryData)
+function multcov!{M<:MatF64}(s::MatF64, k::Stationary, X::M, data::StationaryData)
     nobsv = size(X, 2)
     R = distance(k, X, data)
     for j in 1:nobsv
@@ -62,6 +62,7 @@ function multcov!(s::AbstractMatrix{Float64}, k::Stationary, X::Matrix{Float64},
     end
     return R
 end
+dk_dlσ(k::Stationary, r::Float64) = 2.0*cov(k,r)
 
 # Isotropic Kernels
 
@@ -71,15 +72,15 @@ type IsotropicData <: StationaryData
     R::Matrix{Float64}
 end
 
-function KernelData(k::Isotropic, X::Matrix{Float64})
+function KernelData{M<:MatF64}(k::Isotropic, X::M)
      IsotropicData(distance(k, X))
 end
-function kernel_data_key(k::Isotropic, X::Matrix{Float64})
+function kernel_data_key{M<:MatF64}(k::Isotropic, X::M)
     return Symbol(:IsotropicData_, metric(k))
 end
 
-distance(k::Isotropic, X::Matrix{Float64}, data::IsotropicData) = data.R
-function addcov!(s::AbstractMatrix{Float64}, k::Isotropic, X::Matrix{Float64}, data::IsotropicData)
+distance{M<:MatF64}(k::Isotropic, X::M, data::IsotropicData) = data.R
+function addcov!{M<:MatF64}(s::MatF64, k::Isotropic, X::M, data::IsotropicData)
     nobsv = size(X, 2)
     R = distance(k, X, data)
     for j in 1:nobsv
@@ -90,13 +91,13 @@ function addcov!(s::AbstractMatrix{Float64}, k::Isotropic, X::Matrix{Float64}, d
     end
     return R
 end
-@inline function dKij_dθp(kern::Isotropic,X::Matrix{Float64},i::Int,j::Int,p::Int,dim::Int)
+@inline function dKij_dθp{M<:MatF64}(kern::Isotropic,X::M,i::Int,j::Int,p::Int,dim::Int)
     return dk_dθp(kern, distij(metric(kern),X,i,j,dim),p)
 end
-@inline function dKij_dθp(kern::Isotropic,X::Matrix{Float64},data::IsotropicData,i::Int,j::Int,p::Int,dim::Int)
+@inline function dKij_dθp{M<:MatF64}(kern::Isotropic,X::M,data::IsotropicData,i::Int,j::Int,p::Int,dim::Int)
     return dk_dθp(kern, data.R[i,j],p)
 end
-function grad_kern(kern::Isotropic, x::Vector{Float64}, y::Vector{Float64})
+function grad_kern{V1<:VecF64,V2<:VecF64}(kern::Isotropic, x::V1, y::V2)
     dist=distance(kern,x,y)
     return [dk_dθp(kern,dist,k) for k in 1:num_params(kern)]
 end
@@ -110,7 +111,7 @@ type StationaryARDData <: StationaryData
 end
 
 # May need to customized in subtypes
-function KernelData(k::StationaryARD, X::Matrix{Float64})
+function KernelData{M<:MatF64}(k::StationaryARD, X::M)
     dim, nobsv = size(X)
     dist_stack = Array(Float64, nobsv, nobsv, dim)
     for d in 1:dim
@@ -119,9 +120,9 @@ function KernelData(k::StationaryARD, X::Matrix{Float64})
     end
     StationaryARDData(dist_stack)
 end
-kernel_data_key(k::StationaryARD, X::Matrix{Float64}) = Symbol(:StationaryARDData, metric(k))
+kernel_data_key{M<:MatF64}(k::StationaryARD, X::M) = Symbol(:StationaryARDData, metric(k))
 
-function distance(k::StationaryARD, X::Matrix{Float64}, data::StationaryARDData)
+function distance{M<:MatF64}(k::StationaryARD, X::M, data::StationaryARDData)
     ### This commented section is slower than recalculating the distance from scratch...
     # nobsv = size(data.dist_stack,1)
     # d = length(k.ℓ2)
@@ -129,36 +130,35 @@ function distance(k::StationaryARD, X::Matrix{Float64}, data::StationaryARDData)
     # return reshape(sum(weighted, 3), (nobsv, nobsv))
     return pairwise(metric(k), X)
 end
-@inline distijk(dist::SqEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
-@inline function distij(dist::SqEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+@inline distijk{M<:MatF64}(dist::SqEuclidean,X::M,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
+@inline function distij{M<:MatF64}(dist::SqEuclidean,X::M,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += distijk(dist,X,i,j,k)
     end
     return s
 end
-@inline distijk(dist::Euclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
-@inline function distij(dist::Euclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+@inline distijk{M<:MatF64}(dist::Euclidean,X::M,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
+@inline function distij{M<:MatF64}(dist::Euclidean,X::M,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += distijk(dist,X,i,j,k)
     end
     return √s
 end
-@inline distijk(dist::WeightedSqEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
-@inline function distij(dist::WeightedSqEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+@inline distijk{M<:MatF64}(dist::WeightedSqEuclidean,X::M,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
+@inline function distij{M<:MatF64}(dist::WeightedSqEuclidean,X::M,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += distijk(dist,X,i,j,k)
     end
     return s
 end
-@inline dist2ijk(dist::WeightedEuclidean,X::Matrix{Float64},i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
-@inline function distij(dist::WeightedEuclidean,X::Matrix{Float64},i::Int,j::Int,dim::Int)
+@inline dist2ijk{M<:MatF64}(dist::WeightedEuclidean,X::M,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*dist.weights[k]
+@inline function distij{M<:MatF64}(dist::WeightedEuclidean,X::M,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += dist2ijk(dist,X,i,j,k)
     end
     return √s
 end
-dk_dlσ(k::Stationary, r::Float64) = 2.0*cov(k,r)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@
 # Return:
 * `D::Matrix{Float64}`: Matrix D such that `D[i,j] = f(X[:,i], Y[:,j])`
 """ ->
-function map_column_pairs!(D::Matrix{Float64}, f::Function, X::Matrix{Float64}, Y::Matrix{Float64})
+function map_column_pairs!{M1<:MatF64,M2<:MatF64,M3<:MatF64}(D::M1, f::Function, X::M2, Y::M3)
     dim, nobs1 = size(X)
     nobs2 = size(Y,2)
     dim == size(Y,1) || throw(ArgumentError("Input observation matrices must have consistent dimensions"))
@@ -37,7 +37,7 @@ end
 # Return:
 * `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = f(X[:,i], Y[:,j])`
 """ ->
-function map_column_pairs(f::Function, X::Matrix{Float64}, Y::Matrix{Float64})
+function map_column_pairs{M1<:MatF64,M2<:MatF64}(f::Function, X::M1, Y::M2)
     nobs1 = size(X,2)
     nobs2 = size(Y,2)
     D= Array(Float64, nobs1, nobs2)
@@ -58,7 +58,7 @@ Populates D matrix by applying a function to each pair of columns of an input ma
 * `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = d(X[:,i], X[:,j])`
 
 """ ->
-function map_column_pairs!(D::AbstractMatrix{Float64}, f::Function, X::Matrix{Float64})
+function map_column_pairs!{M1<:MatF64,M2<:MatF64}(D::M1, f::Function, X::M2)
     dim, nobsv = size(X)
     size(D,1) == nobsv || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)", 
                                                        size(D,1), nobsv)))
@@ -84,7 +84,7 @@ Constructs matrix by applying a function to each pair of columns of an input mat
 * `D::Matrix{Float64}`: Symmetric matrix D such that `D[i,j] = d(X[:,i], X[:,j])`
 
 """ ->
-function map_column_pairs(f::Function, X::Matrix{Float64})
+function map_column_pairs{M<:MatF64}(f::Function, X::M)
     dim, nobsv = size(X)
     D = Array(Float64, nobsv, nobsv)
     for i in 1:nobsv


### PR DESCRIPTION
A `Masked` kernel type is a wrapper for kernels so
that they are only applied along certain dimensions of `X`.
This is similar to the `active_dims` kernel attribute in the python GPy 
package and to the `covMask` function in the matlab gpml package.

The implementation is very simple: any function of the kernel
that takes an `X::Matrix` input is delegated to the wrapped 
kernel along with a view of the X matrix that only includes
the active dimensions.

Because views are of type AbstractMatrix rather than Matrix,
the first commit changes all functions that take `X::Matrix{Float64}`
to take `X::MatF64` instead, where `MatF64` is an alias for `AbstractMatrix{Float64}.`

Thanks to julia's array views, there's almost no performance penalty.
Here's a quick illustration:

```{julia}
nobsv=1000
X = randn(2,nobsv)
Y = randn(nobsv)
se = SEIso(0.0, 0.0)
seard=SEArd([0.0, Inf], 0.0)
ksub = Masked(se, [1])
gpsub = GP(X, Y, MeanZero(), ksub, 0.0)
gpard = GP(X, Y, MeanZero(), seard, 0.0)
gp = GP(X, Y, MeanZero(), se, 0.0)
buf1=Array(Float64, nobsv,nobsv)
buf2=Array(Float64, nobsv,nobsv)
@time update_mll_and_dmll!(gp, buf1, buf2)
@time update_mll_and_dmll!(gpsub, buf1, buf2)
```
```
  0.091473 seconds (9.25 k allocations: 360.619 KB)
  0.081157 seconds (8.98 k allocations: 344.578 KB)
```
```{julia}
@printf("mLL using SEIso: %.3f\n", gp.mLL)
# an ARD with one of the lengthscales set to infinity
# should be the same as a masked kernel
# as a quick check, let's verify the marginal
# likelihoods are the same:
@printf("mLL using masked: %.3f\n", gpsub.mLL)
@printf("mLL using SEArd: %.3f\n", gpard.mLL)
@assert isapprox(gpsub.mLL, gpard.mLL)
```
```
mLL using SEIso: -1421.459
mLL using masked: -1415.538
mLL using SEArd: -1415.538
```