### PR TITLE
add Calculus explicitly as a test requirement

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+Calculus


### PR DESCRIPTION
currently getting lucky that Calculus happens to be an indirect dependency
of something else - that's not guaranteed to always be the case