### PR TITLE
Relaxing function signatures to make them work with ForwardDiff

### DIFF
--- a/src/GP.jl
+++ b/src/GP.jl
@@ -9,13 +9,13 @@ Return posterior mean and variance of the Gaussian Process `gp` at specfic point
 given as columns of matrix `X`. If `full_cov` is `true`, the full covariance matrix is
 returned instead of only variances.
 """
-function predict_f(gp::GPBase, x::MatF64; full_cov::Bool=false)
+function predict_f(gp::GPBase, x::AbstractArray{T, 2}; full_cov::Bool=false) where T
     size(x,1) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
     if full_cov
         return _predict(gp, x)
     else
         ## Calculate prediction for each point independently
-            μ = Array{Float64}(undef, size(x,2))
+            μ = Array{T}(undef, size(x,2))
             σ2 = similar(μ)
         for k in 1:size(x,2)
             m, sig = _predict(gp, x[:,k:k])

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -9,13 +9,13 @@ Return posterior mean and variance of the Gaussian Process `gp` at specfic point
 given as columns of matrix `X`. If `full_cov` is `true`, the full covariance matrix is
 returned instead of only variances.
 """
-function predict_f(gp::GPBase, x::AbstractArray{T, 2}; full_cov::Bool=false) where T
+function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
     size(x,1) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
     if full_cov
         return _predict(gp, x)
     else
         ## Calculate prediction for each point independently
-            μ = Array{T}(undef, size(x,2))
+            μ = Array{eltype(x)}(undef, size(x,2))
             σ2 = similar(μ)
         for k in 1:size(x,2)
             m, sig = _predict(gp, x[:,k:k])

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -27,7 +27,7 @@ function predict_f(gp::GPBase, x::AbstractArray{T, 2}; full_cov::Bool=false) whe
 end
 
 # 1D Case for prediction
-predict_f(gp::GPBase, x::VecF64; full_cov::Bool=false) = predict_f(gp, x'; full_cov=full_cov)
+predict_f(gp::GPBase, x::AbstractVector; full_cov::Bool=false) = predict_f(gp, x'; full_cov=full_cov)
 
 wrap_cK(cK::PDMat, Σbuffer, chol::Cholesky) = PDMat(Σbuffer, chol)
 mat(cK::PDMat) = cK.mat
@@ -44,7 +44,7 @@ but have negative eigenvalues numerically. To resolve this issue, small weights 
 to the diagonal (and hereby all eigenvalues are raised by that amount mathematically)
 until all eigenvalues are positive numerically.
 """
-function make_posdef!(m::MatF64, chol_factors::MatF64)
+function make_posdef!(m::AbstractMatrix, chol_factors::AbstractMatrix)
     n = size(m, 1)
     size(m, 2) == n || throw(ArgumentError("Covariance matrix must be square"))
     for _ in 1:10 # 10 chances
@@ -69,7 +69,7 @@ function make_posdef!(m::MatF64, chol_factors::MatF64)
     chol = cholesky!(Symmetric(chol_factors, :U))
     return m, chol
 end
-function make_posdef!(m::MatF64)
+function make_posdef!(m::AbstractMatrix)
     chol_buffer = similar(m)
     return make_posdef!(m, chol_buffer)
 end

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -1,6 +1,6 @@
 # Main GaussianProcess type
 
-mutable struct GPE{X<:MatF64,Y<:VecF64,M<:Mean,K<:Kernel,P<:AbstractPDMat,D<:KernelData} <: GPBase
+mutable struct GPE{X<:AbstractMatrix,Y<:AbstractVector,M<:Mean,K<:Kernel,P<:AbstractPDMat,D<:KernelData} <: GPBase
     # Observation data
     "Input observations"
     x::X
@@ -58,10 +58,10 @@ assumed that the observations are noise free.
 - `logNoise::Float64`: Natural logarithm of the standard deviation for the observation
   noise. The default is -2.0, which is equivalent to assuming no observation noise.
 """
-function GPE(x::MatF64, y::VecF64, mean::Mean, kernel::Kernel, data::KernelData, cK::AbstractPDMat, logNoise::Float64) 
+function GPE(x::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, data::KernelData, cK::AbstractPDMat, logNoise::Float64) 
     GPE{typeof(x),typeof(y),typeof(mean),typeof(kernel),typeof(cK),typeof(data)}(x, y, mean, kernel, data, cK, logNoise)
 end
-function GPE(x::MatF64, y::VecF64, mean::Mean, kernel::Kernel, logNoise::Float64 = -2.0)
+function GPE(x::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64 = -2.0)
     nobs = length(y)
     kerneldata = KernelData(kernel, x)
     Σ = Σ_default(x, kernel, kerneldata, logNoise)
@@ -71,7 +71,7 @@ function GPE(x::MatF64, y::VecF64, mean::Mean, kernel::Kernel, logNoise::Float64
     cK = PDMats.PDMat(m, Cholesky(chol, 'U', 0))
     GPE(x, y, mean, kernel, kerneldata, cK, logNoise)
 end
-GPE(x::VecF64, y::VecF64, mean::Mean, kernel::Kernel, logNoise::Float64 = -2.0) =
+GPE(x::AbstractVector, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64 = -2.0) =
     GPE(x', y, mean, kernel, logNoise)
 
 """
@@ -94,7 +94,7 @@ Fit a Gaussian process that is defined by its `mean`, its `kernel`, and the loga
 
 See also: [`GPE`](@ref)
 """
-GP(x::AbstractVecOrMat{Float64}, y::VecF64, mean::Mean, kernel::Kernel,
+GP(x::AbstractVecOrMat{Float64}, y::AbstractVector, mean::Mean, kernel::Kernel,
    logNoise::Float64 = -2.0) = GPE(x, y, mean, kernel, logNoise)
 
 """
@@ -113,7 +113,7 @@ function fit!(gp::GPE{X,Y}, x::X, y::Y) where {X,Y}
     initialise_target!(gp)
 end
 
-fit!(gp::GPE, x::VecF64, y::VecF64) = fit!(gp, x', y)
+fit!(gp::GPE, x::AbstractVector, y::AbstractVector) = fit!(gp, x', y)
 
 #———————————————————————————————————————————————————————————
 #Fast memory allocation function
@@ -125,7 +125,7 @@ Write `ααᵀ - cK⁻¹` to `ααinvcKI` avoiding any memory allocation, where 
 `α` are the covariance matrix and the alpha vector of a Gaussian process, respectively.
 Hereby `α` is defined as `cK⁻¹ (Y - μ)`.
 """
-function get_ααinvcKI!(ααinvcKI::MatF64, cK::AbstractPDMat, α::Vector)
+function get_ααinvcKI!(ααinvcKI::AbstractMatrix, cK::AbstractPDMat, α::Vector)
     nobs = length(α)
     size(ααinvcKI) == (nobs, nobs) || throw(ArgumentError(
                 @sprintf("Buffer for ααinvcKI should be a %dx%d matrix, not %dx%d",
@@ -181,7 +181,7 @@ function update_mll!(gp::GPE; noise::Bool=true, domean::Bool=true, kern::Bool=tr
     gp
 end
 
-function dmll_kern!(dmll::VecF64, k::Kernel, X::MatF64, data::KernelData, ααinvcKI::MatF64)
+function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, data::KernelData, ααinvcKI::AbstractMatrix)
     dim, nobs = size(X)
     nparams = num_params(k)
     @assert nparams == length(dmll)
@@ -208,7 +208,7 @@ end
 
 Update the gradient of the marginal log-likelihood of Gaussian process `gp`.
 """
-function update_dmll!(gp::GPE, ααinvcKI::MatF64;
+function update_dmll!(gp::GPE, ααinvcKI::AbstractMatrix;
     noise::Bool=true, # include gradient component for the logNoise term
     domean::Bool=true, # include gradient components for the mean parameters
     kern::Bool=true, # include gradient components for the spatial kernel parameters
@@ -249,7 +249,7 @@ Update the gradient of the marginal log-likelihood of a Gaussian
 process `gp`.
 """
 function update_mll_and_dmll!(gp::GPE,
-        ααinvcKI::MatF64;
+        ααinvcKI::AbstractMatrix;
         kwargs...)
     update_mll!(gp; kwargs...)
     update_dmll!(gp, ααinvcKI; kwargs...)
@@ -287,7 +287,7 @@ function update_target!(gp::GPE; noise::Bool=true, domean::Bool=true, kern::Bool
     gp
 end
 
-function update_dtarget!(gp::GPE, Kgrad::MatF64, L_bar::MatF64; kwargs...)
+function update_dtarget!(gp::GPE, Kgrad::AbstractMatrix, L_bar::AbstractMatrix; kwargs...)
     update_dmll!(gp, L_bar; kwargs...)
     gp.dtarget = gp.dmll + prior_gradlogpdf(gp; kwargs...)
     gp
@@ -302,7 +302,7 @@ Update the log-posterior
 ```
 of a Gaussian process `gp` and its derivative.
 """
-function update_target_and_dtarget!(gp::GPE, Kgrad::MatF64, L_bar::MatF64; kwargs...)
+function update_target_and_dtarget!(gp::GPE, Kgrad::AbstractMatrix, L_bar::AbstractMatrix; kwargs...)
     update_target!(gp; kwargs...)
     update_dtarget!(gp, Kgrad, L_bar; kwargs...)
 end
@@ -326,7 +326,7 @@ Return the predictive mean and variance of Gaussian Process `gp` at specfic poin
 are given as columns of matrix `x`. If `full_cov` is `true`, the full covariance matrix is
 returned instead of only variances.
 """
-function predict_y(gp::GPE, x::MatF64; full_cov::Bool=false)
+function predict_y(gp::GPE, x::AbstractMatrix; full_cov::Bool=false)
     μ, σ2 = predict_f(gp, x; full_cov=full_cov)
     if full_cov
         return μ, σ2 + ScalMat(gp.nobs, exp(2*gp.logNoise))
@@ -336,12 +336,12 @@ function predict_y(gp::GPE, x::MatF64; full_cov::Bool=false)
 end
 
 # 1D Case for predictions
-predict_y(gp::GPE, x::VecF64; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
+predict_y(gp::GPE, x::AbstractVector; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
 
 @deprecate predict predict_y
 
 ## compute predictions
-function _predict(gp::GPE, x::MatF64)
+function _predict(gp::GPE, x::AbstractMatrix)
     cK = cov(gp.kernel, gp.x, x)
     Lck = whiten(gp.cK, cK)
     mu = mean(gp.mean, x) + cK'*gp.alpha        # Predictive mean
@@ -353,7 +353,7 @@ end
 
 #———————————————————————————————————————————————————————————
 # Sample from the GPE
-function Random.rand!(gp::GPE, x::MatF64, A::DenseMatrix)
+function Random.rand!(gp::GPE, x::AbstractMatrix, A::DenseMatrix)
     nobs = size(x,2)
     n_sample = size(A,2)
 
@@ -370,14 +370,14 @@ function Random.rand!(gp::GPE, x::MatF64, A::DenseMatrix)
     return broadcast!(+, A, μ, unwhiten!(Σ,randn(nobs, n_sample)))
 end
 
-Random.rand(gp::GPE, x::MatF64, n::Int) = rand!(gp, x, Array{Float64}(undef, size(x, 2), n))
+Random.rand(gp::GPE, x::AbstractMatrix, n::Int) = rand!(gp, x, Array{Float64}(undef, size(x, 2), n))
 
 # Sample from 1D GPE
-Random.rand(gp::GPE, x::VecF64, n::Int) = rand(gp, x', n)
+Random.rand(gp::GPE, x::AbstractVector, n::Int) = rand(gp, x', n)
 
 # Generate only one sample from the GPE and returns a vector
-Random.rand(gp::GPE, x::MatF64) = vec(rand(gp,x,1))
-Random.rand(gp::GPE, x::VecF64) = vec(rand(gp,x',1))
+Random.rand(gp::GPE, x::AbstractMatrix) = vec(rand(gp,x,1))
+Random.rand(gp::GPE, x::AbstractVector) = vec(rand(gp,x',1))
 
 #—————————————————————————————————————————————————————–
 #Functions for setting and calling the parameters of the GP object
@@ -402,7 +402,7 @@ function num_params(gp::GPE; noise::Bool=true, domean::Bool=true, kern::Bool=tru
     n
 end
 
-function set_params!(gp::GPE, hyp::VecF64;
+function set_params!(gp::GPE, hyp::AbstractVector;
                      noise::Bool=true, domean::Bool=true, kern::Bool=true)
     n_mean_params = num_params(gp.mean)
     n_kern_params = num_params(gp.kernel)
@@ -437,7 +437,7 @@ end
 
 #———————————————————————————————————————————————————————————-
 # Push function
-function Base.push!(gp::GPE, x::MatF64, y::VecF64)
+function Base.push!(gp::GPE, x::AbstractMatrix, y::AbstractVector)
     @warn "push! method is currently inefficient as it refits all observations"
     if gp.nobs == 0
         GaussianProcesses.fit!(gp, x, y)
@@ -448,9 +448,9 @@ function Base.push!(gp::GPE, x::MatF64, y::VecF64)
     end
 end
 
-Base.push!(gp::GPE, x::VecF64, y::VecF64) = push!(gp, x', y)
+Base.push!(gp::GPE, x::AbstractVector, y::AbstractVector) = push!(gp, x', y)
 Base.push!(gp::GPE, x::Float64, y::Float64) = push!(gp, [x], [y])
-Base.push!(gp::GPE, x::VecF64, y::Float64) = push!(gp, reshape(x, length(x), 1), [y])
+Base.push!(gp::GPE, x::AbstractVector, y::Float64) = push!(gp, reshape(x, length(x), 1), [y])
 
 
 # —————————————————————————————————————————————————————————————

--- a/src/GPMC.jl
+++ b/src/GPMC.jl
@@ -1,6 +1,6 @@
 # Main GaussianProcess type
 
-mutable struct GPMC{X<:MatF64,Y<:AbstractVector{<:Real},M<:Mean,K<:Kernel,L<:Likelihood,
+mutable struct GPMC{X<:AbstractMatrix,Y<:AbstractVector{<:Real},M<:Mean,K<:Kernel,L<:Likelihood,
                     D<:KernelData} <: GPBase
     # Observation data
     "Input observations"
@@ -66,11 +66,11 @@ values are represented by centered (whitened) variables ``f(x) = m(x) + Lv`` whe
 - `kernel::Kernel`: Covariance function
 - `lik::Likelihood`: Likelihood function
 """
-GPMC(x::MatF64, y::AbstractVector{<:Real}, mean::Mean, kernel::Kernel, lik::Likelihood) =
+GPMC(x::AbstractMatrix, y::AbstractVector{<:Real}, mean::Mean, kernel::Kernel, lik::Likelihood) =
     GPMC{typeof(x),typeof(y),typeof(mean),typeof(kernel),typeof(lik)}(x, y, mean, kernel,
                                                                       lik)
 
-GPMC(x::VecF64, y::AbstractVector{<:Real}, mean::Mean, kernel::Kernel, lik::Likelihood) =
+GPMC(x::AbstractVector, y::AbstractVector{<:Real}, mean::Mean, kernel::Kernel, lik::Likelihood) =
     GPMC(x', y, mean, kernel, lik)
 
 """
@@ -137,7 +137,7 @@ end
 
 Update the gradient of the log-likelihood of Gaussian process `gp`.
 """
-function update_dll!(gp::GPMC, Kgrad::MatF64, L_bar::MatF64;
+function update_dll!(gp::GPMC, Kgrad::AbstractMatrix, L_bar::AbstractMatrix;
     process::Bool=true, # include gradient components for the process itself
     lik::Bool=true,  # include gradient components for the likelihood parameters
     domean::Bool=true, # include gradient components for the mean parameters
@@ -202,7 +202,7 @@ function update_dll!(gp::GPMC, Kgrad::MatF64, L_bar::MatF64;
     gp
 end
 
-function update_ll_and_dll!(gp::GPMC, Kgrad::MatF64, L_bar::MatF64; kwargs...)
+function update_ll_and_dll!(gp::GPMC, Kgrad::AbstractMatrix, L_bar::AbstractMatrix; kwargs...)
     update_ll!(gp; kwargs...)
     update_dll!(gp, Kgrad, L_bar; kwargs...)
 end
@@ -240,7 +240,7 @@ function update_target!(gp::GPMC; process::Bool=true, lik::Bool=true, domean::Bo
     gp
 end
 
-function update_dtarget!(gp::GPMC, Kgrad::MatF64, L_bar::MatF64; kwargs...)
+function update_dtarget!(gp::GPMC, Kgrad::AbstractMatrix, L_bar::AbstractMatrix; kwargs...)
     update_dll!(gp, Kgrad, L_bar; kwargs...)
     gp.dtarget = gp.dll + prior_gradlogpdf(gp; kwargs...)
     gp
@@ -255,7 +255,7 @@ Update the log-posterior
 ```
 of a Gaussian process `gp` and its derivative.
 """
-function update_target_and_dtarget!(gp::GPMC, Kgrad::MatF64, L_bar::MatF64; kwargs...)
+function update_target_and_dtarget!(gp::GPMC, Kgrad::AbstractMatrix, L_bar::AbstractMatrix; kwargs...)
     update_target!(gp; kwargs...)
     update_dtarget!(gp, Kgrad, L_bar; kwargs...)
 end
@@ -274,17 +274,17 @@ Return the predictive mean and variance of Gaussian Process `gp` at specfic poin
 are given as columns of matrix `x`. If `full_cov` is `true`, the full covariance matrix is
 returned instead of only variances.
 """
-function predict_y(gp::GPMC, x::MatF64; full_cov::Bool=false)
+function predict_y(gp::GPMC, x::AbstractMatrix; full_cov::Bool=false)
     μ, σ2 = predict_f(gp, x; full_cov=full_cov)
     return predict_obs(gp.lik, μ, σ2)
 end
 
 # 1D Case for prediction
-predict_y(gp::GPMC, x::VecF64; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
+predict_y(gp::GPMC, x::AbstractVector; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
 
 
 ## compute predictions
-function _predict(gp::GPMC, x::MatF64)
+function _predict(gp::GPMC, x::AbstractMatrix)
     cK = cov(gp.kernel, gp.x, x)
     Lck = whiten(gp.cK, cK)
     fmu =  mean(gp.mean,x) + Lck'gp.v     # Predictive mean
@@ -296,7 +296,7 @@ end
 
 
 # Sample from functions from the GP
-function Random.rand!(gp::GPMC, x::MatF64, A::DenseMatrix)
+function Random.rand!(gp::GPMC, x::AbstractMatrix, A::DenseMatrix)
     nobs = size(x,2)
     n_sample = size(A,2)
 
@@ -313,14 +313,14 @@ function Random.rand!(gp::GPMC, x::MatF64, A::DenseMatrix)
     return broadcast!(+, A, μ, unwhiten!(Σ,randn(nobs, n_sample)))
 end
 
-Random.rand(gp::GPMC, x::MatF64, n::Int) = rand!(gp, x, Array{Float64}(undef, size(x, 2), n))
+Random.rand(gp::GPMC, x::AbstractMatrix, n::Int) = rand!(gp, x, Array{Float64}(undef, size(x, 2), n))
 
 # Sample from 1D GP
-Random.rand(gp::GPMC, x::VecF64, n::Int) = rand(gp, x', n)
+Random.rand(gp::GPMC, x::AbstractVector, n::Int) = rand(gp, x', n)
 
 # Generate only one sample from the GP and returns a vector
-Random.rand(gp::GPMC, x::MatF64) = vec(rand(gp,x,1))
-Random.rand(gp::GPMC, x::VecF64) = vec(rand(gp,x',1))
+Random.rand(gp::GPMC, x::AbstractMatrix) = vec(rand(gp,x,1))
+Random.rand(gp::GPMC, x::AbstractVector) = vec(rand(gp,x',1))
 
 
 function get_params(gp::GPMC; lik::Bool=true, domean::Bool=true, kern::Bool=true)
@@ -346,7 +346,7 @@ function num_params(gp::GPMC; lik::Bool=true, domean::Bool=true, kern::Bool=true
     n
 end
 
-function set_params!(gp::GPMC, hyp::VecF64; process::Bool=true, lik::Bool=true, domean::Bool=true, kern::Bool=true)
+function set_params!(gp::GPMC, hyp::AbstractVector; process::Bool=true, lik::Bool=true, domean::Bool=true, kern::Bool=true)
     n_lik_params = num_params(gp.lik)
     n_mean_params = num_params(gp.mean)
     n_kern_params = num_params(gp.kernel)

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -16,8 +16,8 @@ export GPBase, GP, GPE, GPMC, predict_f, predict_y, Kernel, Likelihood, Composit
     set_priors!,set_params!, update_target!
 
 
-const MatF64 = AbstractMatrix{Float64}
-const VecF64 = AbstractVector{Float64}
+const MatF64 = AbstractMatrix
+const VecF64 = AbstractVector
 
 const φ = normpdf
 const Φ = normcdf

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -16,8 +16,6 @@ export GPBase, GP, GPE, GPMC, ElasticGPE, predict_f, predict_y, Kernel, Likeliho
     set_priors!,set_params!, update_target!
 
 
-const MatF64 = AbstractMatrix
-const VecF64 = AbstractVector
 
 const φ = normpdf
 const Φ = normcdf

--- a/src/ScikitLearn.jl
+++ b/src/ScikitLearn.jl
@@ -4,9 +4,9 @@ import ScikitLearnBase
 
 ScikitLearnBase.is_classifier(::GPE) = false
 
-ScikitLearnBase.fit!(gp::GPE, X::MatF64, y::VecF64) = fit!(gp, X', y)
+ScikitLearnBase.fit!(gp::GPE, X::AbstractMatrix, y::AbstractVector) = fit!(gp, X', y)
 
-function ScikitLearnBase.predict(gp::GPE, X::MatF64; eval_MSE::Bool=false)
+function ScikitLearnBase.predict(gp::GPE, X::AbstractMatrix; eval_MSE::Bool=false)
     mu, Sigma = predict_y(gp, X'; full_cov=false)
     if eval_MSE
         return mu, Sigma

--- a/src/common.jl
+++ b/src/common.jl
@@ -70,7 +70,7 @@ end
 
 num_params(obj::CompositeMeanOrKernel) = sum(num_params, components(obj))
 
-function set_params!(obj::CompositeMeanOrKernel, hyp::VecF64)
+function set_params!(obj::CompositeMeanOrKernel, hyp::AbstractVector)
     length(hyp) == num_params(obj) ||
         throw(ArgumentError("$(typeof(obj)) object requires $(num_params(obj)) hyperparameters"))
     i = 1

--- a/src/kernels/composite_kernel.jl
+++ b/src/kernels/composite_kernel.jl
@@ -13,7 +13,7 @@ struct CompositeData <: KernelData
     keys::Vector{String}
 end
 
-function KernelData(compkern::CompositeKernel, X::MatF64)
+function KernelData(compkern::CompositeKernel, X::AbstractMatrix)
     datadict = Dict{String, KernelData}()
     datakeys = String[]
     for k in components(compkern)
@@ -26,6 +26,6 @@ function KernelData(compkern::CompositeKernel, X::MatF64)
     CompositeData(datadict, datakeys)
 end
 
-function kernel_data_key(compkern::CompositeKernel, X::MatF64)
+function kernel_data_key(compkern::CompositeKernel, X::AbstractMatrix)
     join(["CompositeData" ; sort(unique(kernel_data_key(k, X) for k in components(compkern)))])
 end

--- a/src/kernels/const.jl
+++ b/src/kernels/const.jl
@@ -21,7 +21,7 @@ mutable struct Const <: Kernel
     Const(lσ::Float64) = new(exp(2 * lσ), [])
 end
 
-function set_params!(cons::Const, hyp::VecF64)
+function set_params!(cons::Const, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Constant kernel only has one parameters"))
     cons.σ2 = exp(2.0*hyp[1])
 end
@@ -31,19 +31,19 @@ get_param_names(cons::Const) = [:lσ]
 num_params(cons::Const) = 1
 
 Statistics.cov(cons::Const) = cons.σ2
-function Statistics.cov(cons::Const, x::VecF64, y::VecF64)
+function Statistics.cov(cons::Const, x::AbstractVector, y::AbstractVector)
     return cov(cons)
 end
 
 @inline dk_dlσ(cons::Const) = 2.0*cov(cons)
-@inline function dKij_dθp(cons::Const, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(cons::Const, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p == 1
         return dk_dlσ(cons)
     else
         return NaN
     end
 end
-@inline function dKij_dθp(cons::Const, X::MatF64, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(cons::Const, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     if p == 1
         return dKij_dθp(cons, X, i, j, p, dim)
     else

--- a/src/kernels/distance.jl
+++ b/src/kernels/distance.jl
@@ -1,13 +1,13 @@
-# distance(k::Stationary, X::MatF64, Y::MatF64) = pairwise(metric(k), X, Y)
-distance(k::Stationary, x::VecF64, y::VecF64) = evaluate(metric(k), x, y)
+# distance(k::Stationary, X::AbstractMatrix, Y::AbstractMatrix) = pairwise(metric(k), X, Y)
+distance(k::Stationary, x::AbstractVector, y::AbstractVector) = evaluate(metric(k), x, y)
 
-distance(k::Isotropic, X::MatF64, data::IsotropicData) = data.R
-function distance(k::Stationary, X::MatF64)
+distance(k::Isotropic, X::AbstractMatrix, data::IsotropicData) = data.R
+function distance(k::Stationary, X::AbstractMatrix)
     nobsv = size(X, 2)
     return distance!(Matrix{Float64}(undef, nobsv, nobsv), metric(k), X)
 end
-distance!(dist::MatF64, k::Stationary, X::MatF64) = distance!(dist, metric(k), X)
-function distance!(dist::MatF64, m::PreMetric, X::MatF64)
+distance!(dist::AbstractMatrix, k::Stationary, X::AbstractMatrix) = distance!(dist, metric(k), X)
+function distance!(dist::AbstractMatrix, m::PreMetric, X::AbstractMatrix)
     dim, nobsv = size(X)
     for i in 1:nobsv
         dist[i,i] = 0.0
@@ -17,13 +17,13 @@ function distance!(dist::MatF64, m::PreMetric, X::MatF64)
     end
     return dist
 end
-function distance(k::Stationary, X::MatF64, Y::MatF64)
+function distance(k::Stationary, X::AbstractMatrix, Y::AbstractMatrix)
     nobsx = size(X, 2)
     nobsy = size(Y, 2)
     return distance!(Matrix{Float64}(undef, nobsx, nobsy), metric(k), X, Y)
 end
-distance!(dist::MatF64, k::Stationary, X::MatF64, Y::MatF64) = distance!(dist, metric(k), X, Y)
-function distance!(dist::MatF64, m::PreMetric, X::MatF64, Y::MatF64)
+distance!(dist::AbstractMatrix, k::Stationary, X::AbstractMatrix, Y::AbstractMatrix) = distance!(dist, metric(k), X, Y)
+function distance!(dist::AbstractMatrix, m::PreMetric, X::AbstractMatrix, Y::AbstractMatrix)
     dimx, nobsx = size(X)
     dimy, nobsy = size(Y)
     dimx == dimy || error("size(X, 1) != size(Y, 1)")
@@ -34,19 +34,19 @@ function distance!(dist::MatF64, m::PreMetric, X::MatF64, Y::MatF64)
     end
     return dist
 end
-function distance(k::StationaryARD, X::MatF64, data::StationaryARDData)
+function distance(k::StationaryARD, X::AbstractMatrix, data::StationaryARDData)
     distance(k, X)
 end
-@inline _SqEuclidean_ijk(X::MatF64,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
-@inline _SqEuclidean_ijk(X1::MatF64,X2::MatF64,i::Int,j::Int,k::Int)=(X1[k,i]-X2[k,j])^2
-@inline function _SqEuclidean_ij(X::MatF64,i::Int,j::Int,dim::Int)
+@inline _SqEuclidean_ijk(X::AbstractMatrix,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2
+@inline _SqEuclidean_ijk(X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=(X1[k,i]-X2[k,j])^2
+@inline function _SqEuclidean_ij(X::AbstractMatrix,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += _SqEuclidean_ijk(X,i,j,k)
     end
     return s
 end
-@inline function _SqEuclidean_ij(X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)
+@inline function _SqEuclidean_ij(X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += _SqEuclidean_ijk(X1,X2,i,j,k)
@@ -54,25 +54,25 @@ end
     return s
 end
 # Squared Euclidean
-# @inline distijk(dist::SqEuclidean,X::MatF64,i::Int,j::Int,k::Int)=_SqEuclidean_ijk(X,i,j,k)
-# @inline distijk(dist::SqEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,k::Int)=_SqEuclidean_ijk(X1,X2,i,j,k)
-@inline distij(dist::SqEuclidean,X::MatF64,i::Int,j::Int,dim::Int)=_SqEuclidean_ij(X,i,j,dim)
-@inline distij(dist::SqEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)=_SqEuclidean_ij(X1,X2,i,j,dim)
+# @inline distijk(dist::SqEuclidean,X::AbstractMatrix,i::Int,j::Int,k::Int)=_SqEuclidean_ijk(X,i,j,k)
+# @inline distijk(dist::SqEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=_SqEuclidean_ijk(X1,X2,i,j,k)
+@inline distij(dist::SqEuclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=_SqEuclidean_ij(X,i,j,dim)
+@inline distij(dist::SqEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=_SqEuclidean_ij(X1,X2,i,j,dim)
 
 # Euclidean
-@inline distij(dist::Euclidean,X::MatF64,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X,i,j,dim)
-@inline distij(dist::Euclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X1,X2,i,j,dim)
+@inline distij(dist::Euclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X,i,j,dim)
+@inline distij(dist::Euclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X1,X2,i,j,dim)
 
-@inline _WeightedSqEuclidean_ijk(weights::VecF64,X::MatF64,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*weights[k]
-@inline _WeightedSqEuclidean_ijk(weights::VecF64,X1::MatF64,X2::MatF64,i::Int,j::Int,k::Int)=(X1[k,i]-X2[k,j])^2*weights[k]
-@inline function _WeightedSqEuclidean_ij(weights::VecF64,X::MatF64,i::Int,j::Int,dim::Int)
+@inline _WeightedSqEuclidean_ijk(weights::AbstractVector,X::AbstractMatrix,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*weights[k]
+@inline _WeightedSqEuclidean_ijk(weights::AbstractVector,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=(X1[k,i]-X2[k,j])^2*weights[k]
+@inline function _WeightedSqEuclidean_ij(weights::AbstractVector,X::AbstractMatrix,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += _WeightedSqEuclidean_ijk(weights,X,i,j,k)
     end
     return s
 end
-@inline function _WeightedSqEuclidean_ij(weights::VecF64,X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)
+@inline function _WeightedSqEuclidean_ij(weights::AbstractVector,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
     s = 0.0
     @inbounds @simd for k in 1:dim
         s += _WeightedSqEuclidean_ijk(weights,X1,X2,i,j,k)
@@ -81,13 +81,13 @@ end
 end
 
 # Weighted Squared Euclidean
-@inline distijk(dist::WeightedSqEuclidean,X::MatF64,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X,i,j,k)
-@inline distijk(dist::WeightedSqEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X1,X2,i,j,k)
-@inline distij(dist::WeightedSqEuclidean,X::MatF64,i::Int,j::Int,dim::Int)=_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
-@inline distij(dist::WeightedSqEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)=_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
+@inline distijk(dist::WeightedSqEuclidean,X::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X,i,j,k)
+@inline distijk(dist::WeightedSqEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X1,X2,i,j,k)
+@inline distij(dist::WeightedSqEuclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
+@inline distij(dist::WeightedSqEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
 
 # Weighted Euclidean
-@inline dist2ijk(dist::WeightedEuclidean,X::MatF64,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X,i,j,k)
-@inline dist2ijk(dist::WeightedEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X1,X2,i,j,k)
-@inline distij(dist::WeightedEuclidean,X::MatF64,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
-@inline distij(dist::WeightedEuclidean,X1::MatF64,X2::MatF64,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
+@inline dist2ijk(dist::WeightedEuclidean,X::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X,i,j,k)
+@inline dist2ijk(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X1,X2,i,j,k)
+@inline distij(dist::WeightedEuclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
+@inline distij(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)

--- a/src/kernels/fixed_kernel.jl
+++ b/src/kernels/fixed_kernel.jl
@@ -51,29 +51,29 @@ function free(k::FixedKernel, par::Symbol)
     return FixedKernel(k.kernel, free)
 end
 
-function grad_slice!(dK::MatF64, k::FixedKernel, X::MatF64, data::KernelData, p::Int)
+function grad_slice!(dK::AbstractMatrix, k::FixedKernel, X::AbstractMatrix, data::KernelData, p::Int)
     return grad_slice!(dK, k.kernel, X, data, k.free[p])
 end
-function grad_slice!(dK::MatF64, k::FixedKernel, X::MatF64, data::EmptyData, p::Int)
+function grad_slice!(dK::AbstractMatrix, k::FixedKernel, X::AbstractMatrix, data::EmptyData, p::Int)
     return grad_slice!(dK, k.kernel, X, data, k.free[p])
 end
-@inline function dKij_dθp(fk::FixedKernel,X::MatF64,i::Int,j::Int,p::Int,dim::Int)
+@inline function dKij_dθp(fk::FixedKernel,X::AbstractMatrix,i::Int,j::Int,p::Int,dim::Int)
     return dKij_dθp(fk.kernel, X, i, j, fk.free[p], dim)
 end
-@inline function dKij_dθp(fk::FixedKernel,X::MatF64,data::KernelData,i::Int,j::Int,p::Int,dim::Int)
+@inline function dKij_dθp(fk::FixedKernel,X::AbstractMatrix,data::KernelData,i::Int,j::Int,p::Int,dim::Int)
     return dKij_dθp(fk.kernel, X, data, i, j, fk.free[p], dim)
 end
 
 # delegate everything else to the wrapped kernel
 # (is there a better way to do this?)
-cov_ij(fk::FixedKernel, X::MatF64, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X, i, j, dim)
-cov_ij(fk::FixedKernel, X::MatF64, data::KernelData, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X, data, i, j, dim)
-cov_ij(fk::FixedKernel, X::MatF64, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(fk, X, i, j, dim)
-Statistics.cov(fk::FixedKernel, x::VecF64, y::VecF64) = cov(fk.kernel, x, y)
+cov_ij(fk::FixedKernel, X::AbstractMatrix, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X, i, j, dim)
+cov_ij(fk::FixedKernel, X::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X, data, i, j, dim)
+cov_ij(fk::FixedKernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(fk, X, i, j, dim)
+Statistics.cov(fk::FixedKernel, x::AbstractVector, y::AbstractVector) = cov(fk.kernel, x, y)
 KernelData(fk::FixedKernel, args...) = KernelData(fk.kernel, args...)
-KernelData(fk::FixedKernel, X::MatF64) = KernelData(fk.kernel, X)
+KernelData(fk::FixedKernel, X::AbstractMatrix) = KernelData(fk.kernel, X)
 kernel_data_key(fk::FixedKernel, args...) = kernel_data_key(fk.kernel, args...)
-kernel_data_key(fk::FixedKernel, X::MatF64) = kernel_data_key(fk.kernel, X)
+kernel_data_key(fk::FixedKernel, X::AbstractMatrix) = kernel_data_key(fk.kernel, X)
 
 ##########
 # Priors #

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -63,9 +63,9 @@ function cov!(cK::MatF64, k::Kernel, X::MatF64)
     end
     return cK
 end
-function Statistics.cov(k::Kernel, X::MatF64)
+function Statistics.cov(k::Kernel, X::AbstractArray{T, 2}) where T
     dim, nobsv = size(X)
-    cK = Array{Float64}(undef, nobsv, nobsv)
+    cK = Array{T}(undef, nobsv, nobsv)
     cov!(cK, k, X)
 end
 function cov!(cK::MatF64, k::Kernel, X::MatF64, data::KernelData)

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -19,8 +19,8 @@ Default empty `KernelData`.
 """
 struct EmptyData <: KernelData end
 
-KernelData(k::Kernel, X::MatF64) = EmptyData()
-kernel_data_key(k::Kernel, X::MatF64) = "EmptyData"
+KernelData(k::Kernel, X::AbstractMatrix) = EmptyData()
+kernel_data_key(k::Kernel, X::AbstractMatrix) = "EmptyData"
 
 """
     cov(k::Kernel, X₁::Matrix{Float64}, X₂::Matrix{Float64})
@@ -28,7 +28,7 @@ kernel_data_key(k::Kernel, X::MatF64) = "EmptyData"
 Create covariance matrix from kernel `k` and matrices of observations `X₁` and `X₂`, where
 each column is an observation.
 """
-function Statistics.cov(k::Kernel, X₁::MatF64, X₂::MatF64)
+function Statistics.cov(k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix)
     d(x1,x2) = cov(k, x1, x2)
     return map_column_pairs(d, X₁, X₂)
 end
@@ -38,7 +38,7 @@ end
 
 Like [`cov(k, X₁, X₂)`](@ref), but stores the result in `cK` rather than a new matrix.
 """
-function cov!(cK::MatF64, k::Kernel, X₁::MatF64, X₂::MatF64)
+function cov!(cK::AbstractMatrix, k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix)
     d(x1,x2) = cov(k, x1, x2)
     return map_column_pairs!(cK, d, X₁, X₂)
 end
@@ -49,10 +49,10 @@ end
 Create covariance function from kernel `k`, matrix of observations `X`, where each column is
 an observation, and kernel data `data` constructed from input observations.
 """
-Statistics.cov(k::Kernel, X::MatF64, data::EmptyData) = cov(k, X)
-cov!(k::Kernel, X::MatF64, data::EmptyData) = cov!(cK, k, X)
+Statistics.cov(k::Kernel, X::AbstractMatrix, data::EmptyData) = cov(k, X)
+cov!(k::Kernel, X::AbstractMatrix, data::EmptyData) = cov!(cK, k, X)
 
-function cov!(cK::MatF64, k::Kernel, X::MatF64)
+function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix)
     dim, nobsv = size(X)
     @inbounds for j in 1:nobsv
         cK[j,j] = cov_ij(k, X, j, j, dim)
@@ -68,7 +68,7 @@ function Statistics.cov(k::Kernel, X::AbstractArray{T, 2}) where T
     cK = Array{T}(undef, nobsv, nobsv)
     cov!(cK, k, X)
 end
-function cov!(cK::MatF64, k::Kernel, X::MatF64, data::KernelData)
+function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData)
     dim, nobsv = size(X)
     @inbounds for j in 1:nobsv
         cK[j,j] = cov_ij(k, X, data, j, j, dim)
@@ -79,32 +79,32 @@ function cov!(cK::MatF64, k::Kernel, X::MatF64, data::KernelData)
     end
     return cK
 end
-function Statistics.cov(k::Kernel, X::MatF64, data::KernelData)
+function Statistics.cov(k::Kernel, X::AbstractMatrix, data::KernelData)
     dim, nobsv = size(X)
     cK = Array{Float64}(undef, nobsv, nobsv)
     cov!(cK, k, X, data)
 end
 
-@inline cov_ij(k::Kernel, X::MatF64, i::Int, j::Int, dim::Int) = cov(k, @view(X[:,i]), @view(X[:,j]))
-@inline cov_ij(k::Kernel, X::MatF64, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(k, X, i, j, dim)
+@inline cov_ij(k::Kernel, X::AbstractMatrix, i::Int, j::Int, dim::Int) = cov(k, @view(X[:,i]), @view(X[:,j]))
+@inline cov_ij(k::Kernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(k, X, i, j, dim)
 
 ############################
 ##### Kernel Gradients #####
 ############################
-@inline @inbounds function dKij_dθ!(dK::VecF64, kern::Kernel, X::MatF64, 
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Kernel, X::AbstractMatrix, 
                                     i::Int, j::Int, dim::Int, npars::Int)
     for p in 1:npars
         dK[p] = dKij_dθp(kern, X, i, j, p, dim)
     end
 end
-@inline @inbounds function dKij_dθ!(dK::VecF64, kern::Kernel, X::MatF64, data::KernelData, 
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Kernel, X::AbstractMatrix, data::KernelData, 
                                     i::Int, j::Int, dim::Int, npars::Int)
     for iparam in 1:npars
         dK[iparam] = dKij_dθp(kern, X, data, i, j, iparam, dim)
     end
 end
 
-function grad_slice!(dK::MatF64, k::Kernel, X::MatF64, data::KernelData, p::Int)
+function grad_slice!(dK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData, p::Int)
     dim = size(X,1)
     @inbounds for j in 1:size(X, 2)
         @simd for i in 1:j
@@ -115,7 +115,7 @@ function grad_slice!(dK::MatF64, k::Kernel, X::MatF64, data::KernelData, p::Int)
     return dK
 end
 
-function grad_slice!(dK::MatF64, k::Kernel, X::MatF64, data::EmptyData, p::Int)
+function grad_slice!(dK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::EmptyData, p::Int)
     dim = size(X, 1)
     @inbounds for j in 1:size(X, 2)
         @simd for i in 1:j
@@ -127,19 +127,19 @@ function grad_slice!(dK::MatF64, k::Kernel, X::MatF64, data::EmptyData, p::Int)
 end
 
 # Calculates the stack [dk / dθᵢ] of kernel matrix gradients
-function grad_stack!(stack::AbstractArray, k::Kernel, X::MatF64, data::KernelData)
+function grad_stack!(stack::AbstractArray, k::Kernel, X::AbstractMatrix, data::KernelData)
     @inbounds for p in 1:num_params(k)
         grad_slice!(view(stack, :, :, p), k, X, data, p)
     end
     stack
 end
 
-grad_stack!(stack::AbstractArray, k::Kernel, X::MatF64) =
+grad_stack!(stack::AbstractArray, k::Kernel, X::AbstractMatrix) =
     grad_stack!(stack, k, X, KernelData(k, X))
 
-grad_stack(k::Kernel, X::MatF64) = grad_stack(k, X, KernelData(k, X))
+grad_stack(k::Kernel, X::AbstractMatrix) = grad_stack(k, X, KernelData(k, X))
 
-function grad_stack(k::Kernel, X::MatF64, data::KernelData)
+function grad_stack(k::Kernel, X::AbstractMatrix, data::KernelData)
     nobs = size(X, 2)
     stack = Array{Float64}(undef, nobs, nobs, num_params(k))
     grad_stack!(stack, k, X, data)

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -63,9 +63,9 @@ function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix)
     end
     return cK
 end
-function Statistics.cov(k::Kernel, X::AbstractArray{T, 2}) where T
+function Statistics.cov(k::Kernel, X::AbstractMatrix)
     dim, nobsv = size(X)
-    cK = Array{T}(undef, nobsv, nobsv)
+    cK = Array{eltype(X)}(undef, nobsv, nobsv)
     cov!(cK, k, X)
 end
 function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData)

--- a/src/kernels/lin.jl
+++ b/src/kernels/lin.jl
@@ -1,7 +1,7 @@
 # Linear covariance function
 
-@inline dotijp(X::MatF64, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
-@inline function dotij(X::MatF64, i::Int, j::Int, dim::Int)
+@inline dotijp(X::AbstractMatrix, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
+@inline function dotij(X::AbstractMatrix, i::Int, j::Int, dim::Int)
 	s=zero(eltype(X))
 	@inbounds @simd for p in 1:dim
 		s+=dotijp(X,i,j,p)

--- a/src/kernels/lin_iso.jl
+++ b/src/kernels/lin_iso.jl
@@ -27,27 +27,27 @@ struct LinIsoData{D} <: KernelData
     XtX::D
 end
 
-function KernelData(k::LinIso, X::MatF64)
+function KernelData(k::LinIso, X::AbstractMatrix)
     XtX=X'*X
     LinearAlgebra.copytri!(XtX, 'U') # make sure it's symmetric
     LinIsoData(XtX)
 end
-kernel_data_key(k::LinIso, X::MatF64) = "LinIsoData"
+kernel_data_key(k::LinIso, X::AbstractMatrix) = "LinIsoData"
 
 _cov(lin::LinIso, xTy) = xTy ./ lin.ℓ2
-function Statistics.cov(lin::LinIso, x::VecF64, y::VecF64)
+function Statistics.cov(lin::LinIso, x::AbstractVector, y::AbstractVector)
     K = _cov(lin, dot(x,y))
     return K
 end
 
-@inline @inbounds function cov_ij(lin::LinIso, X::MatF64, data::LinIsoData, i::Int, j::Int, dim::Int)
+@inline @inbounds function cov_ij(lin::LinIso, X::AbstractMatrix, data::LinIsoData, i::Int, j::Int, dim::Int)
     return _cov(lin, data.XtX[i, j])
 end
-function Statistics.cov(lin::LinIso, X::MatF64, data::LinIsoData)
+function Statistics.cov(lin::LinIso, X::AbstractMatrix, data::LinIsoData)
     K = _cov(lin, data.XtX)
     return K
 end
-function cov!(cK::MatF64, lin::LinIso, X::MatF64, data::LinIsoData)
+function cov!(cK::AbstractMatrix, lin::LinIso, X::AbstractMatrix, data::LinIsoData)
     iℓ2 = 1/lin.ℓ2
     @inbounds @simd for I in eachindex(cK,data.XtX)
         cK[I] = data.XtX[I]*iℓ2
@@ -59,20 +59,20 @@ get_params(lin::LinIso) = Float64[log(lin.ℓ2) / 2]
 get_param_names(::LinIso) = [:ll]
 num_params(lin::LinIso) = 1
 
-function set_params!(lin::LinIso, hyp::VecF64)
+function set_params!(lin::LinIso, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Linear isotropic kernel only has one parameter"))
     lin.ℓ2 = exp(2 * hyp[1])
 end
 
 @inline dk_dll(lin::LinIso, xTy::Float64) = -2 * _cov(lin,xTy)
-@inline function dKij_dθp(lin::LinIso, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(lin::LinIso, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p==1
         return dk_dll(lin, dotij(X,i,j,dim))
     else
         return NaN
     end
 end
-@inline function dKij_dθp(lin::LinIso, X::MatF64, data::LinIsoData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(lin::LinIso, X::AbstractMatrix, data::LinIsoData, i::Int, j::Int, p::Int, dim::Int)
     if p==1
         return dk_dll(lin, data.XtX[i,j])
     else

--- a/src/kernels/masked_kernel.jl
+++ b/src/kernels/masked_kernel.jl
@@ -21,47 +21,47 @@ function Masked(kern::Kernel, active_dims::AbstractVector{Int})
     return Masked{K,dim}(kern, SVector{dim, Int}(active_dims))
 end
 
-@inline function cov_ij(masked::Masked, X::MatF64, i::Int, j::Int, dim::Int)
+@inline function cov_ij(masked::Masked, X::AbstractMatrix, i::Int, j::Int, dim::Int)
     return cov_ij(masked.kernel, @view(X[masked.active_dims, :]), i, j, num_dims(masked))
 end
-@inline function cov_ij(masked::Masked, X::MatF64, data::KernelData, i::Int, j::Int, dim::Int)
+@inline function cov_ij(masked::Masked, X::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int)
     return cov_ij(masked.kernel, @view(X[masked.active_dims, :]), data, i, j, num_dims(masked))
 end
-@inline function cov_ij(masked::Masked, X::MatF64, data::EmptyData, i::Int, j::Int, dim::Int)
+@inline function cov_ij(masked::Masked, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int)
     return cov_ij(masked, X, i, j, dim)
 end
 
-@inline function dKij_dθp(masked::Masked, X::MatF64, data::KernelData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, data::KernelData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(masked.kernel, @view(X[masked.active_dims, :]), data, i, j, p, num_dims(masked))
 end
-@inline function dKij_dθp(masked::Masked, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(masked.kernel, @view(X[masked.active_dims, :]), i, j, p, num_dims(masked))
 end
-@inline function dKij_dθp(masked::Masked, X::MatF64, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(masked, X, i, j, p, dim)
 end
-@inline @inbounds function dKij_dθ!(dK::VecF64, masked::Masked, X::MatF64, data::KernelData, i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, masked::Masked, X::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int, npars::Int)
     Xmasked = @view(X[masked.active_dims,:])
     return dKij_dθ!(dK, masked.kernel, Xmasked, data, i, j, num_dims(masked), npars)
 end
 
-function Statistics.cov(masked::Masked, x1::MatF64, x2::MatF64)
+function Statistics.cov(masked::Masked, x1::AbstractMatrix, x2::AbstractMatrix)
     return cov(masked.kernel, view(x1,masked.active_dims,:), view(x2,masked.active_dims,:))
 end
-function Statistics.cov(masked::Masked, x1::VecF64, x2::VecF64)
+function Statistics.cov(masked::Masked, x1::AbstractVector, x2::AbstractVector)
     return cov(masked.kernel, view(x1,masked.active_dims), view(x2,masked.active_dims))
 end
-function Statistics.cov(masked::Masked, X::MatF64, data::KernelData)
+function Statistics.cov(masked::Masked, X::AbstractMatrix, data::KernelData)
     return cov(masked.kernel, view(X,masked.active_dims,:), data)
 end
 function cov!(
-    s::MatF64, masked::Masked, X::MatF64, data::KernelData)
+    s::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::KernelData)
     return cov!(s, masked.kernel, view(X,masked.active_dims,:), data)
 end
-function KernelData(masked::Masked, X::MatF64)
+function KernelData(masked::Masked, X::AbstractMatrix)
     return KernelData(masked.kernel, view(X,masked.active_dims,:))
 end
-function kernel_data_key(masked::Masked, X::MatF64)
+function kernel_data_key(masked::Masked, X::AbstractMatrix)
     k = kernel_data_key(masked.kernel, view(X,masked.active_dims,:))
     return @sprintf("%s_active=%s", k, masked.active_dims)
 end
@@ -71,18 +71,18 @@ get_param_names(masked::Masked) = get_param_names(masked.kernel)
 num_params(masked::Masked) = num_params(masked.kernel)
 set_params!(masked::Masked, hyp) = set_params!(masked.kernel, hyp)
 function grad_slice!(
-    dK::MatF64, masked::Masked, X::MatF64, data::KernelData, iparam::Int)
+    dK::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::KernelData, iparam::Int)
     return grad_slice!(dK, masked.kernel, view(X,masked.active_dims,:), data, iparam)
 end
 
 # with EmptyData
-function Statistics.cov(masked::Masked, X::MatF64, data::EmptyData)
+function Statistics.cov(masked::Masked, X::AbstractMatrix, data::EmptyData)
     return cov(masked.kernel, view(X,masked.active_dims,:), data)
 end
-function cov!(s::MatF64, masked::Masked, X::MatF64, data::EmptyData)
+function cov!(s::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::EmptyData)
     return cov!(s, masked.kernel, view(X,masked.active_dims,:), data)
 end
-function grad_slice!(dK::MatF64, masked::Masked, X::MatF64, data::EmptyData, iparam::Int)
+function grad_slice!(dK::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::EmptyData, iparam::Int)
     return grad_slice!(dK, masked.kernel, view(X,masked.active_dims,:), data, iparam)
 end
 

--- a/src/kernels/mat.jl
+++ b/src/kernels/mat.jl
@@ -2,7 +2,7 @@
 abstract type MaternIso <: Isotropic{Euclidean} end
 abstract type MaternARD <: StationaryARD{WeightedEuclidean} end
 
-@inline function dKij_dθp(mat::MaternARD, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(mat::MaternARD, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     r=distij(metric(mat),X,i,j,dim)
     if p <= dim
         wdiffp=dist2ijk(metric(mat),X,i,j,p)
@@ -13,7 +13,7 @@ abstract type MaternARD <: StationaryARD{WeightedEuclidean} end
         return NaN
     end
 end
-@inline function dKij_dθp(mat::MaternARD, X::MatF64, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(mat::MaternARD, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(mat,X,i,j,p,dim)
 end
 

--- a/src/kernels/mat12_ard.jl
+++ b/src/kernels/mat12_ard.jl
@@ -36,6 +36,6 @@ get_params(mat::Mat12Ard) = [-log.(mat.iℓ2) / 2; log(mat.σ2) / 2]
 get_param_names(mat::Mat12Ard) = [get_param_names(mat.iℓ2, :ll); :lσ]
 num_params(mat::Mat12Ard) = length(mat.iℓ2) + 1
 
-Statistics.cov(mat::Mat12Ard, r::Float64) = mat.σ2 * exp(-r)
+Statistics.cov(mat::Mat12Ard, r::Number) = mat.σ2 * exp(-r)
 
 dk_dll(mat::Mat12Ard, r::Float64, wdiffp::Float64) = wdiffp / r * cov(mat,r)

--- a/src/kernels/mat12_ard.jl
+++ b/src/kernels/mat12_ard.jl
@@ -26,7 +26,7 @@ mutable struct Mat12Ard <: MaternARD
     Mat12Ard(ll::Vector{Float64}, lσ::Float64) = new(exp.(-2 .* ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat12Ard, hyp::VecF64)
+function set_params!(mat::Mat12Ard, hyp::AbstractVector)
     length(hyp) == num_params(mat) || throw(ArgumentError("Mat12 kernel only has $(num_params(mat)) parameters"))
     @views @. mat.iℓ2  = exp(-2 * hyp[1:(end-1)])
     mat.σ2 = exp(2 * hyp[end])

--- a/src/kernels/mat12_iso.jl
+++ b/src/kernels/mat12_iso.jl
@@ -34,6 +34,6 @@ get_params(mat::Mat12Iso) = Float64[log(mat.ℓ), log(mat.σ2) / 2]
 get_param_names(mat::Mat12Iso) = [:ll, :lσ]
 num_params(mat::Mat12Iso) = 2
 
-Statistics.cov(mat::Mat12Iso, r::Float64) = mat.σ2 * exp(-r / mat.ℓ)
+Statistics.cov(mat::Mat12Iso, r::Number) = mat.σ2 * exp(-r / mat.ℓ)
 
 @inline dk_dll(mat::Mat12Iso, r::Float64) = r / mat.ℓ * cov(mat, r)

--- a/src/kernels/mat12_iso.jl
+++ b/src/kernels/mat12_iso.jl
@@ -25,7 +25,7 @@ mutable struct Mat12Iso <: MaternIso
     Mat12Iso(ll::Float64, lσ::Float64) = new(exp(ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat12Iso, hyp::VecF64)
+function set_params!(mat::Mat12Iso, hyp::AbstractVector)
     length(hyp) == 2 || throw(ArgumentError("Matern 1/2 covariance function only has two parameters"))
     mat.ℓ, mat.σ2 = exp(hyp[1]), exp(2 * hyp[2])
 end

--- a/src/kernels/mat32_ard.jl
+++ b/src/kernels/mat32_ard.jl
@@ -36,7 +36,7 @@ get_params(mat::Mat32Ard) = [-log.(mat.iℓ2) / 2; log(mat.σ2) / 2]
 get_param_names(mat::Mat32Ard) = [get_param_names(mat.iℓ2, :ll); :lσ]
 num_params(mat::Mat32Ard) = length(mat.iℓ2) + 1
 
-Statistics.cov(mat::Mat32Ard, r::Float64) =
+Statistics.cov(mat::Mat32Ard, r::Number) =
     (s = √3 * r; mat.σ2 * (1 + s) * exp(-s))
 
 dk_dll(mat::Mat32Ard, r::Float64, wdiffp::Float64) = 3 * mat.σ2 * wdiffp * exp(-√3 * r)

--- a/src/kernels/mat32_ard.jl
+++ b/src/kernels/mat32_ard.jl
@@ -26,7 +26,7 @@ mutable struct Mat32Ard <: MaternARD
     Mat32Ard(ll::Vector{Float64}, lσ::Float64) = new(exp.(-2 .* ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat32Ard, hyp::VecF64)
+function set_params!(mat::Mat32Ard, hyp::AbstractVector)
     length(hyp) == num_params(mat) || throw(ArgumentError("Mat32 kernel only has $(num_params(mat)) parameters"))
     @views @. mat.iℓ2 = exp(-2 * hyp[1:(end-1)])
     mat.σ2 = exp(2 * hyp[end])

--- a/src/kernels/mat32_iso.jl
+++ b/src/kernels/mat32_iso.jl
@@ -34,7 +34,7 @@ get_params(mat::Mat32Iso) = Float64[log(mat.ℓ), log(mat.σ2) / 2 ]
 get_param_names(mat::Mat32Iso) = [:ll, :lσ]
 num_params(mat::Mat32Iso) = 2
 
-Statistics.cov(mat::Mat32Iso, r::Float64) =
+Statistics.cov(mat::Mat32Iso, r::Number) =
     (s = √3 * r / mat.ℓ; mat.σ2 * (1 + s) * exp(-s))
 
 @inline dk_dll(mat::Mat32Iso, r::Float64) =

--- a/src/kernels/mat32_iso.jl
+++ b/src/kernels/mat32_iso.jl
@@ -25,7 +25,7 @@ mutable struct Mat32Iso <: MaternIso
     Mat32Iso(ll::Float64, lσ::Float64) = new(exp(ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat32Iso, hyp::VecF64)
+function set_params!(mat::Mat32Iso, hyp::AbstractVector)
     length(hyp) == 2 || throw(ArgumentError("Matern 3/2 only has two parameters"))
     mat.ℓ, mat.σ2 = exp(hyp[1]), exp(2 * hyp[2])
 end

--- a/src/kernels/mat52_ard.jl
+++ b/src/kernels/mat52_ard.jl
@@ -36,7 +36,7 @@ get_params(mat::Mat52Ard) = [-log.(mat.iℓ2) / 2; log(mat.σ2) / 2]
 get_param_names(mat::Mat52Ard) = [get_param_names(mat.iℓ2, :ll); :lσ]
 num_params(mat::Mat52Ard) = length(mat.iℓ2) + 1
 
-Statistics.cov(mat::Mat52Ard, r::Float64) =
+Statistics.cov(mat::Mat52Ard, r::Number) =
     (s = √5 * r; mat.σ2 * (1 + s + s^2 / 3) * exp(-s))
 
 dk_dll(mat::Mat52Ard, r::Float64, wdiffp::Float64) =

--- a/src/kernels/mat52_ard.jl
+++ b/src/kernels/mat52_ard.jl
@@ -26,7 +26,7 @@ mutable struct Mat52Ard <: MaternARD
     Mat52Ard(ll::Vector{Float64}, lσ::Float64) = new(exp.(-2 .* ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat52Ard, hyp::VecF64)
+function set_params!(mat::Mat52Ard, hyp::AbstractVector)
     length(hyp) == num_params(mat) || throw(ArgumentError("Mat52 kernel only has $(num_params(mat)) parameters"))
     @views @. mat.iℓ2 = exp(-2 * hyp[1:(end-1)])
     mat.σ2 = exp(2 * hyp[end])

--- a/src/kernels/mat52_iso.jl
+++ b/src/kernels/mat52_iso.jl
@@ -33,7 +33,7 @@ get_params(mat::Mat52Iso) = Float64[log(mat.ℓ), log(mat.σ2) / 2]
 get_param_names(mat::Mat52Iso) = [:ll, :lσ]
 num_params(mat::Mat52Iso) = 2
 
-Statistics.cov(mat::Mat52Iso, r::Float64) =
+Statistics.cov(mat::Mat52Iso, r::Number) =
     (s = √5 * r / mat.ℓ; mat.σ2 * (1 + s + s^2 / 3) * exp(-s))
 
 @inline dk_dll(mat::Mat52Iso, r::Float64) =

--- a/src/kernels/mat52_iso.jl
+++ b/src/kernels/mat52_iso.jl
@@ -25,7 +25,7 @@ mutable struct Mat52Iso <: MaternIso
     Mat52Iso(ll::Float64, lσ::Float64) = new(exp(ll), exp(2 * lσ), [])
 end
 
-function set_params!(mat::Mat52Iso, hyp::VecF64)
+function set_params!(mat::Mat52Iso, hyp::AbstractVector)
     length(hyp) == 2 || throw(ArgumentError("Matern 5/2 only has two parameters"))
     mat.ℓ, mat.σ2 = exp(hyp[1]), exp(2 * hyp[2])
 end

--- a/src/kernels/noise.jl
+++ b/src/kernels/noise.jl
@@ -24,20 +24,20 @@ mutable struct Noise <: Kernel
 end
 
 Statistics.cov(noise::Noise, sameloc::Bool) = sameloc ? noise.σ2 : 0.0
-Statistics.cov(noise::Noise, x::VecF64, y::VecF64) = cov(noise, euclidean(x, y) < eps())
+Statistics.cov(noise::Noise, x::AbstractVector, y::AbstractVector) = cov(noise, euclidean(x, y) < eps())
 
 get_params(noise::Noise) = Float64[log(noise.σ2) / 2]
 get_param_names(noise::Noise) = [:lσ]
 num_params(noise::Noise) = 1
 
-function set_params!(noise::Noise, hyp::VecF64)
+function set_params!(noise::Noise, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Noise kernel only has one parameter"))
     noise.σ2 = exp(2 * hyp[1])
 end
 
-dKij_dθp(noise::Noise, X::MatF64, i::Int, j::Int, p::Int, dim::Int) =
+dKij_dθp(noise::Noise, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int) =
     2 * cov(noise, view(X, :, i), view(X, :, j))
 
-@inline function dKij_dθp(noise::Noise, X::MatF64, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(noise::Noise, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(noise, X, i, j, p, dim)
 end

--- a/src/kernels/pair_kernel.jl
+++ b/src/kernels/pair_kernel.jl
@@ -45,7 +45,7 @@ struct PairData{KD1 <: KernelData, KD2 <: KernelData} <: KernelData
     data1::KD1
     data2::KD2
 end
-function KernelData(pairkern::PairKernel, X::MatF64)
+function KernelData(pairkern::PairKernel, X::AbstractMatrix)
     kl = leftkern(pairkern)
     kr = rightkern(pairkern)
     # this is a bit broken:
@@ -60,7 +60,7 @@ function KernelData(pairkern::PairKernel, X::MatF64)
     end
 end
 
-function kernel_data_key(pairkern::PairKernel, X::MatF64)
+function kernel_data_key(pairkern::PairKernel, X::AbstractMatrix)
     kl = leftkern(pairkern)
     kr = rightkern(pairkern)
     @sprintf("PairData:%s+%s", kernel_data_key(kl, X), kernel_data_key(kr, X))

--- a/src/kernels/periodic.jl
+++ b/src/kernels/periodic.jl
@@ -39,7 +39,7 @@ function set_params!(pe::Periodic, hyp::VecF64)
     pe.p = exp(hyp[3])
 end
 
-Statistics.cov(pe::Periodic, r::Float64) = pe.σ2 * exp(-2 / pe.ℓ2 * sin(π * r / pe.p)^2)
+Statistics.cov(pe::Periodic, r::Number) = pe.σ2 * exp(-2 / pe.ℓ2 * sin(π * r / pe.p)^2)
 
 
 @inline dk_dll(pe::Periodic, r::Float64) =

--- a/src/kernels/periodic.jl
+++ b/src/kernels/periodic.jl
@@ -33,7 +33,7 @@ get_params(pe::Periodic) = Float64[log(pe.ℓ2) / 2, log(pe.σ2) / 2, log(pe.p)]
 get_param_names(pe::Periodic) = [:ll, :lσ, :lp]
 num_params(pe::Periodic) = 3
 
-function set_params!(pe::Periodic, hyp::VecF64)
+function set_params!(pe::Periodic, hyp::AbstractVector)
     length(hyp) == 3 || throw(ArgumentError("Periodic function has only three parameters"))
     pe.ℓ2, pe.σ2 = exp(2 * hyp[1]), exp(2 * hyp[2])
     pe.p = exp(hyp[3])

--- a/src/kernels/poly.jl
+++ b/src/kernels/poly.jl
@@ -28,30 +28,30 @@ mutable struct Poly <: Kernel
     Poly(lc::Float64, lσ::Float64, deg::Int) = new(exp(lc), exp(2 * lσ), deg, [])
 end
 
-function KernelData(k::Poly, X::MatF64)
+function KernelData(k::Poly, X::AbstractMatrix)
     XtX=X'*X
     LinearAlgebra.copytri!(XtX, 'U')
     LinIsoData(XtX)
 end
-kernel_data_key(k::Poly, X::MatF64) = "LinIsoData"
+kernel_data_key(k::Poly, X::AbstractMatrix) = "LinIsoData"
 
 _cov(poly::Poly, xTy) = poly.σ2*(poly.c.+xTy).^poly.deg
-function Statistics.cov(poly::Poly, x::VecF64, y::VecF64)
+function Statistics.cov(poly::Poly, x::AbstractVector, y::AbstractVector)
     K = _cov(poly, dot(x,y))
 end
-function cov!(cK::MatF64, poly::Poly, X::MatF64, data::LinIsoData)
+function cov!(cK::AbstractMatrix, poly::Poly, X::AbstractMatrix, data::LinIsoData)
     cK .= _cov(poly, data.XtX)
 end
-@inline @inbounds function cov_ij(poly::Poly, X::MatF64, data::LinIsoData, i::Int, j::Int, dim::Int)
+@inline @inbounds function cov_ij(poly::Poly, X::AbstractMatrix, data::LinIsoData, i::Int, j::Int, dim::Int)
     return _cov(poly, data.XtX[i, j])
 end
-Statistics.cov(poly::Poly, X::MatF64, data::LinIsoData) = _cov(poly, data.XtX)
+Statistics.cov(poly::Poly, X::AbstractMatrix, data::LinIsoData) = _cov(poly, data.XtX)
 
 get_params(poly::Poly) = Float64[log(poly.c), log(poly.σ2) / 2]
 get_param_names(poly::Poly) = [:lc, :lσ]
 num_params(poly::Poly) = 2
 
-function set_params!(poly::Poly, hyp::VecF64)
+function set_params!(poly::Poly, hyp::AbstractVector)
     length(hyp) == 2 || throw(ArgumentError("Polynomial function has two parameters"))
     poly.c = exp(hyp[1])
     poly.σ2 = exp(2 * hyp[2])
@@ -59,14 +59,14 @@ end
 
 @inline dk_dlc(poly::Poly, xTy::Float64) = poly.c*poly.deg*poly.σ2*(poly.c+xTy).^(poly.deg-1)
 @inline dk_dlσ(poly::Poly, xTy::Float64) = 2 * _cov(poly,xTy)
-@inline function dKij_dθp(poly::Poly, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(poly::Poly, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p==1
         return dk_dlc(poly, dotij(X,i,j,dim))
     else
         return dk_dlσ(poly, dotij(X,i,j,dim))
     end
 end
-@inline function dKij_dθp(poly::Poly, X::MatF64, data::LinIsoData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(poly::Poly, X::AbstractMatrix, data::LinIsoData, i::Int, j::Int, p::Int, dim::Int)
     if p==1
         return dk_dlc(poly, data.XtX[i,j])
     else

--- a/src/kernels/prod_kernel.jl
+++ b/src/kernels/prod_kernel.jl
@@ -7,14 +7,14 @@ rightkern(prodkern::ProdKernel) = prodkern.kright
 
 get_param_names(prodkern::ProdKernel) = composite_param_names(components(prodkern), :pk)
 
-function Statistics.cov(sk::ProdKernel, x::VecF64, y::VecF64)
+function Statistics.cov(sk::ProdKernel, x::AbstractVector, y::AbstractVector)
     cov(sk.kleft, x, y) * cov(sk.kright, x, y)
 end
 
-@inline cov_ij(k::ProdKernel, X::MatF64, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X, i, j, dim) * cov_ij(k.kright, X, i, j, dim)
-@inline cov_ij(k::ProdKernel, X::MatF64, data::PairData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X, data.data1, i, j, dim) * cov_ij(k.kright, X, data.data2, i, j, dim)
+@inline cov_ij(k::ProdKernel, X::AbstractMatrix, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X, i, j, dim) * cov_ij(k.kright, X, i, j, dim)
+@inline cov_ij(k::ProdKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X, data.data1, i, j, dim) * cov_ij(k.kright, X, data.data2, i, j, dim)
 
-@inline function dKij_dθp(prodkern::ProdKernel, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(prodkern::ProdKernel, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(prodkern.kleft)
     if p<=np
         cK_other = cov_ij(prodkern.kright, X, i, j, dim)
@@ -24,7 +24,7 @@ end
         return dKij_dθp(prodkern.kright, X, i,j,p-np,dim)*cK_other
     end
 end
-@inline function dKij_dθp(prodkern::ProdKernel, X::MatF64, data::PairData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(prodkern::ProdKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(prodkern.kleft)
     if p<=np
         cK_other = cov_ij(prodkern.kright, X, i, j, dim)
@@ -36,7 +36,7 @@ end
         return dKij_sub * cK_other
     end
 end
-@inline @inbounds function dKij_dθ!(dK::VecF64, prodkern::ProdKernel, X::MatF64, data::PairData, 
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix, data::PairData, 
                                     i::Int, j::Int, dim::Int, npars::Int)
     cov_left  = cov_ij(prodkern.kleft,  X, data.data1, i, j, dim)
     cov_right = cov_ij(prodkern.kright, X, data.data2, i, j, dim)

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -41,7 +41,7 @@ get_params(rq::RQArd) = [-log.(rq.iℓ2) / 2; log(rq.σ2) / 2; log(rq.α)]
 get_param_names(rq::RQArd) = [get_param_names(rq.iℓ2, :ll); :lσ; :lα]
 num_params(rq::RQArd) = length(rq.iℓ2) + 2
 
-Statistics.cov(rq::RQArd,r::Float64) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
+Statistics.cov(rq::RQArd,r::Number) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
 
 @inline dk_dll(rq::RQArd, r::Float64, wdiffp::Float64) =
     rq.σ2 * wdiffp * (1 + r / (2 * rq.α))^(-rq.α - 1)

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -30,7 +30,7 @@ mutable struct RQArd <: StationaryARD{WeightedSqEuclidean}
         new(exp.(-2 .* ll), exp(2 * lσ), exp(lα), [])
 end
 
-function set_params!(rq::RQArd, hyp::VecF64)
+function set_params!(rq::RQArd, hyp::AbstractVector)
     length(hyp) == num_params(rq) || throw(ArgumentError("RQArd kernel has $(num_params(rq_ard)) parameters"))
     @views @. rq.iℓ2 = exp(-2 * hyp[1:(end-2)])
     rq.σ2 = exp(2 * hyp[end-1])
@@ -49,7 +49,7 @@ Statistics.cov(rq::RQArd,r::Number) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
     part = (1 + r / (2 * rq.α))
     return rq.σ2 * part^(-rq.α) * (r / (2 * part) - rq.α * log(part))
 end
-@inline function dKij_dθp(rq::RQArd, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(rq::RQArd, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
         return dk_dll(rq, distij(metric(rq),X,i,j,dim), distijk(metric(rq),X,i,j,p))
     elseif p==dim+1
@@ -58,6 +58,6 @@ end
         return dk_dlα(rq, distij(metric(rq),X,i,j,dim))
     end
 end
-@inline function dKij_dθp(rq::RQArd, X::MatF64, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(rq::RQArd, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(rq,X,i,j,p,dim)
 end

--- a/src/kernels/rq_iso.jl
+++ b/src/kernels/rq_iso.jl
@@ -38,7 +38,7 @@ get_params(rq::RQIso) = Float64[log(rq.ℓ2) / 2, log(rq.σ2) / 2, log(rq.α)]
 get_param_names(rq::RQIso) = [:ll, :lσ, :lα]
 num_params(rq::RQIso) = 3
 
-Statistics.cov(rq::RQIso, r::Float64) = rq.σ2 * (1 + r / (2 * rq.α * rq.ℓ2))^(-rq.α)
+Statistics.cov(rq::RQIso, r::Number) = rq.σ2 * (1 + r / (2 * rq.α * rq.ℓ2))^(-rq.α)
 
 @inline dk_dll(rq::RQIso, r::Float64) =
     (s = r / rq.ℓ2; rq.σ2 * s * (1 + s / (2 * rq.α))^(-rq.α - 1)) # dK_d(log ℓ)dK_dℓ

--- a/src/kernels/rq_iso.jl
+++ b/src/kernels/rq_iso.jl
@@ -29,7 +29,7 @@ mutable struct RQIso <: Isotropic{SqEuclidean}
         new(exp(2 * ll), exp(2 * lσ), exp(lα), [])
 end
 
-function set_params!(rq::RQIso, hyp::VecF64)
+function set_params!(rq::RQIso, hyp::AbstractVector)
     length(hyp) == 3 || throw(ArgumentError("Rational Quadratic function has three parameters"))
     rq.ℓ2, rq.σ2, rq.α = exp(2 * hyp[1]), exp(2 * hyp[2]), exp(hyp[3])
 end

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -36,7 +36,7 @@ get_params(se::SEArd) = [-log.(se.iℓ2) / 2 ; log(se.σ2) / 2]
 get_param_names(k::SEArd) = [get_param_names(k.iℓ2, :ll); :lσ]
 num_params(se::SEArd) = length(se.iℓ2) + 1
 
-Statistics.cov(se::SEArd, r::Float64) = se.σ2*exp(-r / 2)
+Statistics.cov(se::SEArd, r::Number) = se.σ2*exp(-r / 2)
 
 @inline dk_dll(se::SEArd, r::Float64, wdiffp::Float64) = wdiffp*cov(se,r)
 @inline function dKij_dθp(se::SEArd, X::MatF64, i::Int, j::Int, p::Int, dim::Int)

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -26,7 +26,7 @@ mutable struct SEArd <: StationaryARD{WeightedSqEuclidean}
     SEArd(ll::Vector{Float64}, lσ::Float64) = new(exp.(-2 .* ll), exp(2 * lσ), [])
 end
 
-function set_params!(se::SEArd, hyp::VecF64)
+function set_params!(se::SEArd, hyp::AbstractVector)
     length(hyp) == num_params(se) || throw(ArgumentError("SEArd only has $(num_params(se)) parameters"))
     @views @. se.iℓ2 = exp(-2 * hyp[1:(end-1)])
     se.σ2 = exp(2 * hyp[end])
@@ -39,7 +39,7 @@ num_params(se::SEArd) = length(se.iℓ2) + 1
 Statistics.cov(se::SEArd, r::Number) = se.σ2*exp(-r / 2)
 
 @inline dk_dll(se::SEArd, r::Float64, wdiffp::Float64) = wdiffp*cov(se,r)
-@inline function dKij_dθp(se::SEArd, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(se::SEArd, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
         return dk_dll(se, distij(metric(se),X,i,j,dim), distijk(metric(se),X,i,j,p))
     elseif p==dim+1
@@ -48,6 +48,6 @@ Statistics.cov(se::SEArd, r::Number) = se.σ2*exp(-r / 2)
         return NaN
     end
 end
-@inline function dKij_dθp(se::SEArd, X::MatF64, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(se::SEArd, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
     return dKij_dθp(se,X,i,j,p,dim)
 end

--- a/src/kernels/se_iso.jl
+++ b/src/kernels/se_iso.jl
@@ -32,7 +32,7 @@ get_params(se::SEIso) = Float64[log(se.ℓ2) / 2, log(se.σ2) / 2]
 get_param_names(se::SEIso) = [:ll, :lσ]
 num_params(se::SEIso) = 2
 
-Statistics.cov(se::SEIso, r::Float64) = se.σ2*exp(-0.5*r/se.ℓ2)
+Statistics.cov(se::SEIso, r::Number) = se.σ2*exp(-0.5*r/se.ℓ2)
 
 @inline dk_dll(se::SEIso, r::Float64) = r/se.ℓ2*cov(se,r)
 @inline function dk_dθp(se::SEIso, r::Float64, p::Int)

--- a/src/kernels/se_iso.jl
+++ b/src/kernels/se_iso.jl
@@ -23,7 +23,7 @@ mutable struct SEIso <: Isotropic{SqEuclidean}
     SEIso(ll::Float64, lσ::Float64) = new(exp(2 * ll), exp(2 * lσ), [])
 end
 
-function set_params!(se::SEIso, hyp::VecF64)
+function set_params!(se::SEIso, hyp::AbstractVector)
     length(hyp) == 2 || throw(ArgumentError("Squared exponential only has two parameters"))
     se.ℓ2, se.σ2 = exp(2 * hyp[1]), exp(2 * hyp[2])
 end

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -1,5 +1,5 @@
 # Subtypes of Stationary must define the following functions:
-# cov(k::Stationary, r::Float64) = ::Float64
+# cov(k::Stationary, r::Number) = ::Float64
 # grad_kern!
 
 abstract type Stationary{D} <: Kernel where D <: Distances.SemiMetric end
@@ -39,10 +39,10 @@ function cov!(cK::MatF64, k::Stationary, X1::MatF64, X2::MatF64)
     end
     return cK
 end
-function Statistics.cov(k::Stationary, X1::MatF64, X2::MatF64)
+function Statistics.cov(k::Stationary, X1::MatF64, X2::AbstractArray{T, 2}) where T
     nobsv1 = size(X1, 2)
     nobsv2 = size(X2, 2)
-    cK = Array{Float64}(undef, nobsv1, nobsv2)
+    cK = Array{T}(undef, nobsv1, nobsv2)
     cov!(cK, k, X1, X2)
     return cK
 end
@@ -54,8 +54,7 @@ function cov!(cK::MatF64, k::Stationary, X::MatF64)
     met = metric(k)
     @inbounds for i in 1:nobsv
         for j in 1:i
-            cK[i,j] = cov(k, distij(met, X, i, j, dim))
-            cK[j,i] = cK[i,j]
+            cK[i, j] = cK[j, i] = cov(k, distij(met, X, i, j, dim))
         end
     end
     return cK
@@ -68,9 +67,9 @@ function Statistics.cov(k::Stationary, X::MatF64, data::StationaryData)
     cK = Matrix{Float64}(undef, nobsv, nobsv)
     cov!(cK, k, X, data)
 end
-function Statistics.cov(k::Stationary, X::MatF64)
+function Statistics.cov(k::Stationary, X::AbstractArray{T, 2}) where T
     nobsv = size(X, 2)
-    cK = Matrix{Float64}(undef, nobsv, nobsv)
+    cK = Matrix{T}(undef, nobsv, nobsv)
     cov!(cK, k, X)
 end
 dk_dlσ(k::Stationary, r::Float64) = 2 * cov(k,r)

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -39,10 +39,10 @@ function cov!(cK::AbstractMatrix, k::Stationary, X1::AbstractMatrix, X2::Abstrac
     end
     return cK
 end
-function Statistics.cov(k::Stationary, X1::AbstractMatrix, X2::AbstractArray{T, 2}) where T
+function Statistics.cov(k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix)
     nobsv1 = size(X1, 2)
     nobsv2 = size(X2, 2)
-    cK = Array{T}(undef, nobsv1, nobsv2)
+    cK = Array{eltype(X2)}(undef, nobsv1, nobsv2)
     cov!(cK, k, X1, X2)
     return cK
 end
@@ -64,12 +64,12 @@ function cov!(cK::AbstractMatrix, k::Stationary, X::AbstractMatrix, data::Statio
 end
 function Statistics.cov(k::Stationary, X::AbstractMatrix, data::StationaryData)
     nobsv = size(X, 2)
-    cK = Matrix{Float64}(undef, nobsv, nobsv)
+    cK = Matrix{eltype(X)}(undef, nobsv, nobsv)
     cov!(cK, k, X, data)
 end
-function Statistics.cov(k::Stationary, X::AbstractArray{T, 2}) where T
+function Statistics.cov(k::Stationary, X::AbstractMatrix)
     nobsv = size(X, 2)
-    cK = Matrix{T}(undef, nobsv, nobsv)
+    cK = Matrix{eltype(X)}(undef, nobsv, nobsv)
     cov!(cK, k, X)
 end
 dk_dlσ(k::Stationary, r::Float64) = 2 * cov(k,r)

--- a/src/kernels/sum_kernel.jl
+++ b/src/kernels/sum_kernel.jl
@@ -7,14 +7,14 @@ rightkern(sumkern::SumKernel) = sumkern.kright
 
 get_param_names(sumkern::SumKernel) = composite_param_names(components(sumkern), :sk)
 
-function Statistics.cov(sk::SumKernel, x::VecF64, y::VecF64)
+function Statistics.cov(sk::SumKernel, x::AbstractVector, y::AbstractVector)
     cov(sk.kleft, x, y) + cov(sk.kright, x, y)
 end
 
-@inline cov_ij(k::K, X::MatF64, i::Int, j::Int, dim::Int) where {K<:SumKernel} = cov_ij(k.kleft, X, i, j, dim) + cov_ij(k.kright, X, i, j, dim)
-@inline cov_ij(k::K, X::MatF64, data::PairData, i::Int, j::Int, dim::Int) where {K<:SumKernel} = cov_ij(k.kleft, X, data.data1, i, j, dim) + cov_ij(k.kright, X, data.data2, i, j, dim)
+@inline cov_ij(k::K, X::AbstractMatrix, i::Int, j::Int, dim::Int) where {K<:SumKernel} = cov_ij(k.kleft, X, i, j, dim) + cov_ij(k.kright, X, i, j, dim)
+@inline cov_ij(k::K, X::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int) where {K<:SumKernel} = cov_ij(k.kleft, X, data.data1, i, j, dim) + cov_ij(k.kright, X, data.data2, i, j, dim)
     
-@inline function dKij_dθp(sumkern::SumKernel, X::MatF64, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(sumkern::SumKernel, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(sumkern.kleft)
     if p<=np
         return dKij_dθp(sumkern.kleft, X, i, j, p, dim)
@@ -22,7 +22,7 @@ end
         return dKij_dθp(sumkern.kright, X, i, j, p-np, dim)
     end
 end
-@inline function dKij_dθp(sumkern::SumKernel, X::MatF64, data::PairData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(sumkern::SumKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(sumkern.kleft)
     if p<=np
         return dKij_dθp(sumkern.kleft, X, data.data1, i, j, p, dim)
@@ -30,7 +30,7 @@ end
         return dKij_dθp(sumkern.kright, X, data.data2, i, j, p-np, dim)
     end
 end
-@inline @inbounds function dKij_dθ!(dK::VecF64, sumkern::SumKernel, X::MatF64, data::PairData, i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int, npars::Int)
     npright = num_params(sumkern.kright) 
     npleft = num_params(sumkern.kleft)
     dKij_dθ!(dK, sumkern.kright, X, data.data2, i, j, dim, npars-npleft)
@@ -40,7 +40,7 @@ end
     dKij_dθ!(dK,  sumkern.kleft,  X, data.data1, i, j, dim, npleft)
 end
 
-function grad_slice!(dK::MatF64, sumkern::SumKernel, X::MatF64, data::PairData, p::Int)
+function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X::AbstractMatrix, data::PairData, p::Int)
     np = num_params(sumkern.kleft)
     if p<=np
         return grad_slice!(dK, sumkern.kleft, X, data.data1, p)

--- a/src/likelihoods/bernoulli.jl
+++ b/src/likelihoods/bernoulli.jl
@@ -9,24 +9,24 @@ for ``k ∈ \\{0,1\\}``, where ``θ = Φ(f)`` and ``f`` is the latent Gaussian p
 """
 struct BernLik <: Likelihood end
 
-function log_dens(bernoulli::BernLik, f::VecF64, y::Vector{Bool})
+function log_dens(bernoulli::BernLik, f::AbstractVector, y::Vector{Bool})
     return Float64[yi ? log(Φ(fi)) : log(1.0 - Φ(fi)) for (fi,yi) in zip(f,y)]
 end
 
-function dlog_dens_df(bernoulli::BernLik, f::VecF64, y::Vector{Bool})
+function dlog_dens_df(bernoulli::BernLik, f::AbstractVector, y::Vector{Bool})
     return Float64[yi ? φ(fi)/Φ(fi) : -φ(fi)/(1.0 - Φ(fi)) for (fi,yi) in zip(f,y)]
 end
 
 #mean and variance under the likelihood
-mean_lik(bernoulli::BernLik, f::VecF64) = Float64[Φ(fi) for fi in f]
-var_lik(bernoulli::BernLik, f::VecF64) = Float64[Φ(fi)*(1-Φ(fi)) for fi in f]
+mean_lik(bernoulli::BernLik, f::AbstractVector) = Float64[Φ(fi) for fi in f]
+var_lik(bernoulli::BernLik, f::AbstractVector) = Float64[Φ(fi)*(1-Φ(fi)) for fi in f]
 
 get_params(bernoulli::BernLik) = []
 num_params(bernoulli::BernLik) = 0
 
 
 #Computes the predictive mean and variance
-function predict_obs(bernoulli::BernLik, fmean::VecF64, fvar::VecF64)
+function predict_obs(bernoulli::BernLik, fmean::AbstractVector, fvar::AbstractVector)
     p = Float64[Φ(fm./sqrt(1+fv)) for (fm,fv) in zip(fmean,fvar)]
     return p, p-p.*p
 end

--- a/src/likelihoods/binomial.jl
+++ b/src/likelihoods/binomial.jl
@@ -13,18 +13,18 @@ struct BinLik <: Likelihood
     n::Int
 end
 
-function log_dens(binomial::BinLik, f::VecF64, y::Vector{Int})
+function log_dens(binomial::BinLik, f::AbstractVector, y::Vector{Int})
     θ = @. exp(f) / (1 + exp(f))
     return Float64[lgamma(binomial.n+1.0) - lgamma(yi+1.0) - lgamma(binomial.n-yi+1.0) + yi*log(θi) + (binomial.n-yi)*log(1-θi) for (θi,yi) in zip(θ,y)]
 end
 
-function dlog_dens_df(binomial::BinLik, f::VecF64, y::Vector{Int})
+function dlog_dens_df(binomial::BinLik, f::AbstractVector, y::Vector{Int})
     return Float64[yi/(1.0+exp(fi)) - (binomial.n-yi)*exp(fi)/(1+exp(fi)) for (fi,yi) in zip(f,y)]
 end
 
 #mean and variance under the likelihood
-mean_lik(binomial::BinLik, f::VecF64) = Float64[binomial.n*exp(fi)/(1.0+exp(fi)) for fi in f]
-var_lik(binomial::BinLik, f::VecF64) = Float64[binomial.n*(exp(fi)/(1.0+exp(fi)))*(1.0/(1.0+exp(fi))) for fi in f]
+mean_lik(binomial::BinLik, f::AbstractVector) = Float64[binomial.n*exp(fi)/(1.0+exp(fi)) for fi in f]
+var_lik(binomial::BinLik, f::AbstractVector) = Float64[binomial.n*(exp(fi)/(1.0+exp(fi)))*(1.0/(1.0+exp(fi))) for fi in f]
 
 get_params(binomial::BinLik) = []
 num_params(binomial::BinLik) = 0

--- a/src/likelihoods/exponential.jl
+++ b/src/likelihoods/exponential.jl
@@ -10,19 +10,19 @@ where ``θ = \\exp(-f)`` and ``f`` is the latent Gaussian process.
 struct ExpLik <: Likelihood end
 
 #log of probability density
-function log_dens(exponential::ExpLik, f::VecF64, y::VecF64)
+function log_dens(exponential::ExpLik, f::AbstractVector, y::AbstractVector)
     #where we exponentiate for positivity f = exp(fi)
     return [-fi - exp(-fi)*yi for (fi,yi) in zip(f,y)]
 end
 
 #derivative of pdf wrt latent function
-function dlog_dens_df(exponential::ExpLik, f::VecF64, y::VecF64)
+function dlog_dens_df(exponential::ExpLik, f::AbstractVector, y::AbstractVector)
     return [(yi*exp(-fi)-1) for (fi,yi) in zip(f,y)]
 end
 
 #mean and variance under likelihood
-mean_lik(exponential::ExpLik, f::VecF64) = exp.(f)
-var_lik(exponential::ExpLik, f::VecF64) = exp.(f).^2
+mean_lik(exponential::ExpLik, f::AbstractVector) = exp.(f)
+var_lik(exponential::ExpLik, f::AbstractVector) = exp.(f).^2
 
 get_params(exponential::ExpLik) = []
 num_params(exponential::ExpLik) = 0

--- a/src/likelihoods/gaussian.jl
+++ b/src/likelihoods/gaussian.jl
@@ -23,26 +23,26 @@ mutable struct GaussLik <: Likelihood
 end
 
 # log of probability density
-function log_dens(gauss::GaussLik, f::VecF64, y::VecF64)
+function log_dens(gauss::GaussLik, f::AbstractVector, y::AbstractVector)
     return (-0.5 * log(2 * pi) - log(gauss.σ)) .- 0.5 * ((y - f) / gauss.σ).^2
 end
 
 # derivative of log pdf wrt latent function
-function dlog_dens_df(gauss::GaussLik, f::VecF64, y::VecF64)
+function dlog_dens_df(gauss::GaussLik, f::AbstractVector, y::AbstractVector)
     return [(yi-fi)/gauss.σ^2 for (fi,yi) in zip(f,y)]
 end
 
 # derivative of log pdf wrt to parameters
-function dlog_dens_dθ(gauss::GaussLik, f::VecF64, y::VecF64)
+function dlog_dens_dθ(gauss::GaussLik, f::AbstractVector, y::AbstractVector)
     return gauss.σ*[-1/gauss.σ + 1/gauss.σ^3*(yi-fi).^2 for (fi,yi) in zip(f,y)]
 end
 
 #mean and variance under likelihood
-mean_lik(gauss::GaussLik, f::VecF64) = f
-var_lik(gauss::GaussLik, f::VecF64) = ones(length(f))*gauss.σ^2
+mean_lik(gauss::GaussLik, f::AbstractVector) = f
+var_lik(gauss::GaussLik, f::AbstractVector) = ones(length(f))*gauss.σ^2
 
 
-function set_params!(gauss::GaussLik, hyp::VecF64)
+function set_params!(gauss::GaussLik, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Gaussian/Normal likelihood has only one free parameter"))
     gauss.σ = exp(hyp[])
 end
@@ -52,6 +52,6 @@ num_params(gauss::GaussLik) = 1
 
 
 #Computes the predictive mean and variance
-function predict_obs(gauss::GaussLik, fmean::VecF64, fvar::VecF64)
+function predict_obs(gauss::GaussLik, fmean::AbstractVector, fvar::AbstractVector)
     return fmean, fvar + gauss.σ^2
 end

--- a/src/likelihoods/likelihoods.jl
+++ b/src/likelihoods/likelihoods.jl
@@ -13,7 +13,7 @@ include("binomial.jl")
 #Predict observations at test locations
 
 """ Computes the predictive mean and variance given a Gaussian distribution for f using quadrature"""
-function predict_obs(lik::Likelihood, fmean::VecF64, fvar::VecF64)
+function predict_obs(lik::Likelihood, fmean::AbstractVector, fvar::AbstractVector)
     n_gaussHermite = 20
     nodes, weights = gausshermite(n_gaussHermite)
     weights /= sqrtπ

--- a/src/likelihoods/poisson.jl
+++ b/src/likelihoods/poisson.jl
@@ -10,19 +10,19 @@ for ``k ∈ N₀``, where ``θ = \\exp(f)`` and ``f`` is the latent Gaussian pro
 struct PoisLik <: Likelihood end
 
 #log of probability density
-function log_dens(poisson::PoisLik, f::VecF64, y::Vector{Int})
+function log_dens(poisson::PoisLik, f::AbstractVector, y::Vector{Int})
     #where we exponentiate for positivity f = exp(fi)
     return y.*f - exp.(f) - lgamma.(1.0 .+ y)
 end
 
 #derivative of pdf wrt latent function
-function dlog_dens_df(poisson::PoisLik, f::VecF64, y::Vector{Int})
+function dlog_dens_df(poisson::PoisLik, f::AbstractVector, y::Vector{Int})
     return y - exp.(f)
 end
 
 #mean and variance under likelihood
-mean_lik(poisson::PoisLik, f::VecF64) = exp.(f)
-var_lik(poisson::PoisLik, f::VecF64) = exp.(f)
+mean_lik(poisson::PoisLik, f::AbstractVector) = exp.(f)
+var_lik(poisson::PoisLik, f::AbstractVector) = exp.(f)
 
 get_params(poisson::PoisLik) = []
 num_params(poisson::PoisLik) = 0

--- a/src/likelihoods/studentT.jl
+++ b/src/likelihoods/studentT.jl
@@ -26,7 +26,7 @@ mutable struct StuTLik <: Likelihood
 end
 
 #log of probability density
-function log_dens(studentT::StuTLik, f::VecF64, y::VecF64)
+function log_dens(studentT::StuTLik, f::AbstractVector, y::AbstractVector)
     ν = studentT.ν
     σ = studentT.σ
     c = lgamma(0.5*(ν+1)) - lgamma(0.5*ν) - 0.5*log(pi*ν) - log(σ)
@@ -34,24 +34,24 @@ function log_dens(studentT::StuTLik, f::VecF64, y::VecF64)
 end
 
 #derivative of log pdf wrt latent function
-function dlog_dens_df(studentT::StuTLik, f::VecF64, y::VecF64)
+function dlog_dens_df(studentT::StuTLik, f::AbstractVector, y::AbstractVector)
     ν = studentT.ν
     σ = studentT.σ
     return [(ν+1)*(yi-fi)/(ν*σ^2 + (yi-fi)^2) for (fi,yi) in zip(f,y)]
 end
 
 #derivative of log pdf wrt to parameters
-function dlog_dens_dθ(studentT::StuTLik, f::VecF64, y::VecF64)
+function dlog_dens_dθ(studentT::StuTLik, f::AbstractVector, y::AbstractVector)
     ν = studentT.ν
     σ = studentT.σ
     return σ*[-1/σ+(ν+1)*(yi-fi)^2/(ν*σ^3 + σ*(yi-fi)^2) for (fi,yi) in zip(f,y)]
 end
 
 #mean and variance under likelihood
-mean_lik(studentT::StuTLik, f::VecF64) = f
-var_lik(studentT::StuTLik, f::VecF64) = studentT.σ^2*(studentT.ν/(studentT.ν-2.0))*ones(length(f))
+mean_lik(studentT::StuTLik, f::AbstractVector) = f
+var_lik(studentT::StuTLik, f::AbstractVector) = studentT.σ^2*(studentT.ν/(studentT.ν-2.0))*ones(length(f))
 
-function set_params!(studentT::StuTLik, hyp::VecF64)
+function set_params!(studentT::StuTLik, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Student-t likelihood has only one free parameter"))
     studentT.σ = exp(hyp[])
 end

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -11,7 +11,7 @@ function mcmc(gp::GPBase; nIter::Int=1000, burn::Int=1, thin::Int=1, ε::Float64
     L_bar = Array{Float64}(undef, gp.nobs, gp.nobs)
     params_kwargs = get_params_kwargs(gp; domean=domean, kern=kern, noise=noise, lik=lik)
     count = 0
-    function calc_target(gp::GPBase, θ::VecF64) #log-target and its gradient
+    function calc_target(gp::GPBase, θ::AbstractVector) #log-target and its gradient
         count += 1
         try
             set_params!(gp, θ; params_kwargs...)

--- a/src/means/mConst.jl
+++ b/src/means/mConst.jl
@@ -23,17 +23,17 @@ mutable struct MeanConst <: Mean
     MeanConst(β::Float64) = new(β, [])
 end
 
-mean(mConst::MeanConst, x::VecF64) = mConst.β
-mean(mConst::MeanConst, X::MatF64) = fill(mConst.β, size(X,2))
+mean(mConst::MeanConst, x::AbstractVector) = mConst.β
+mean(mConst::MeanConst, X::AbstractMatrix) = fill(mConst.β, size(X,2))
 
 get_params(mConst::MeanConst) = Float64[mConst.β]
 get_param_names(::MeanConst) = [:β]
 num_params(mConst::MeanConst) = 1
-function set_params!(mConst::MeanConst, hyp::VecF64)
+function set_params!(mConst::MeanConst, hyp::AbstractVector)
     length(hyp) == 1 || throw(ArgumentError("Constant mean function only has 1 parameter"))
     mConst.β = hyp[1]
 end
-function grad_mean(mConst::MeanConst, x::VecF64)
+function grad_mean(mConst::MeanConst, x::AbstractVector)
     dM_theta = ones(1)
     return dM_theta
 end

--- a/src/means/mLin.jl
+++ b/src/means/mLin.jl
@@ -23,19 +23,19 @@ mutable struct MeanLin <: Mean
     MeanLin(β::Vector{Float64}) = new(β, [])
 end
 
-mean(mLin::MeanLin, x::VecF64) = dot(mLin.β, x)
-mean(mLin::MeanLin, X::MatF64) = X'mLin.β
+mean(mLin::MeanLin, x::AbstractVector) = dot(mLin.β, x)
+mean(mLin::MeanLin, X::AbstractMatrix) = X'mLin.β
 
 get_params(mLin::MeanLin) = mLin.β
 get_param_names(::MeanLin) = [:β]
 num_params(mLin::MeanLin) = length(mLin.β)
 
-function set_params!(mLin::MeanLin, hyp::VecF64)
+function set_params!(mLin::MeanLin, hyp::AbstractVector)
     length(hyp) == length(mLin.β) || throw(ArgumentError("Linear mean function only has $(mLin.dim) parameters"))
     copyto!(mLin.β, hyp)
 end
 
-function grad_mean(mLin::MeanLin, x::VecF64)
+function grad_mean(mLin::MeanLin, x::AbstractVector)
     dM_theta = x
     return dM_theta
 end

--- a/src/means/mPoly.jl
+++ b/src/means/mPoly.jl
@@ -24,7 +24,7 @@ mutable struct MeanPoly <: Mean
     MeanPoly(β::Matrix{Float64}) = new(β, [])
 end
 
-function mean(mPoly::MeanPoly, x::VecF64)
+function mean(mPoly::MeanPoly, x::AbstractVector)
     dim = length(x)
     deg = size(mPoly.β, 2)
     dim == size(mPoly.β, 1) || throw(ArgumentError("Observations and mean function have inconsistent dimensions"))
@@ -36,13 +36,13 @@ get_params(mPoly::MeanPoly) = vec(mPoly.β)
 get_param_names(mPoly::MeanPoly) = [:β]
 num_params(mPoly::MeanPoly) = length(mPoly.β)
 
-function set_params!(mPoly::MeanPoly, hyp::VecF64)
+function set_params!(mPoly::MeanPoly, hyp::AbstractVector)
     length(hyp) == num_params(mPoly) || throw(ArgumentError("Polynomial mean function has $(num_param) parameters"))
     copyto!(mPoly.β, hyp)
 end
 
 
-function grad_mean(mPoly::MeanPoly, x::VecF64)
+function grad_mean(mPoly::MeanPoly, x::AbstractVector)
     dim = length(x)
     deg = size(mPoly.β, 2)
     dM_theta = Array{Float64}(undef, dim, deg)

--- a/src/means/mZero.jl
+++ b/src/means/mZero.jl
@@ -11,12 +11,12 @@ m(x) = 0.
 struct MeanZero <: Mean end
 
 num_params(::MeanZero) = 0
-grad_mean(::MeanZero, ::VecF64) = Float64[]
-mean(::MeanZero, ::VecF64) = 0.0
-mean(mZero::MeanZero, X::MatF64) =  fill(0.0, size(X, 2))
+grad_mean(::MeanZero, ::AbstractVector) = Float64[]
+mean(::MeanZero, ::AbstractVector) = 0.0
+mean(mZero::MeanZero, X::AbstractMatrix) =  fill(0.0, size(X, 2))
 get_params(::MeanZero) = Float64[]
 get_param_names(::MeanZero) = Symbol[]
 
-function set_params!(::MeanZero, hyp::VecF64)
+function set_params!(::MeanZero, hyp::AbstractVector)
     length(hyp) == 0 || throw(ArgumentError("Zero mean function has no parameters"))
 end

--- a/src/means/means.jl
+++ b/src/means/means.jl
@@ -3,7 +3,7 @@
 abstract type Mean end
 
 # Calculate mean for matrix of observations
-function mean(m::Mean, X::MatF64)
+function mean(m::Mean, X::AbstractMatrix)
     nobs = size(X, 2)
     μ = Array{Float64}(undef, nobs)
     @inbounds for i in 1:nobs
@@ -13,7 +13,7 @@ function mean(m::Mean, X::MatF64)
 end
 
 # Calculates the stack [dm / dθᵢ] of mean matrix gradients
-function grad_stack(m::Mean, X::MatF64)
+function grad_stack(m::Mean, X::AbstractMatrix)
     nobs = size(X, 2)
     mat = Array{Float64}(undef, nobs, num_params(m))
     @inbounds for i in 1:nobs

--- a/src/means/prod_mean.jl
+++ b/src/means/prod_mean.jl
@@ -4,11 +4,11 @@ end
 
 ProdMean(means::Mean...) = ProdMean(means)
 
-mean(pm::ProdMean, x::VecF64) = prod(mean(m, x) for m in components(pm))
+mean(pm::ProdMean, x::AbstractVector) = prod(mean(m, x) for m in components(pm))
 
 get_param_names(pm::ProdMean) = composite_param_names(components(pm), :pm)
 
-function grad_mean(pm::ProdMean, x::VecF64)
+function grad_mean(pm::ProdMean, x::AbstractVector)
     dm = Array{Float64}(undef, num_params(pm))
     means = [mean(m, x) for m in components(pm)]
     v = 1

--- a/src/means/sum_mean.jl
+++ b/src/means/sum_mean.jl
@@ -4,11 +4,11 @@ end
 
 SumMean(means::Mean...) = SumMean(means)
 
-mean(sm::SumMean, x::VecF64) = sum(mean(m, x) for m in components(sm))
+mean(sm::SumMean, x::AbstractVector) = sum(mean(m, x) for m in components(sm))
 
 get_param_names(sm::SumMean) = composite_param_names(components(sm), :sm)
 
-function grad_mean(sm::SumMean, x::VecF64)
+function grad_mean(sm::SumMean, x::AbstractVector)
     dm = Array{Float64}(undef, num_params(sm))
     v = 1
     for m in components(sm)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -26,7 +26,7 @@ function optimize!(gp::GPBase; method = LBFGS(), domean::Bool = true, kern::Bool
 end
 
 function get_optim_target(gp::GPBase; params_kwargs...)
-    function ltarget(hyp::VecF64)
+    function ltarget(hyp::AbstractVector)
         prev = get_params(gp; params_kwargs...)
         try
             set_params!(gp, hyp; params_kwargs...)
@@ -51,7 +51,7 @@ function get_optim_target(gp::GPBase; params_kwargs...)
         end
     end
 
-    function ltarget_and_dltarget!(grad::VecF64, hyp::VecF64)
+    function ltarget_and_dltarget!(grad::AbstractVector, hyp::AbstractVector)
         prev = get_params(gp; params_kwargs...)
         try
             set_params!(gp, hyp; params_kwargs...)
@@ -76,8 +76,8 @@ function get_optim_target(gp::GPBase; params_kwargs...)
         end
     end
 
-    function dltarget!(grad::VecF64, hyp::VecF64)
-        ltarget_and_dltarget!(grad::VecF64, hyp::VecF64)
+    function dltarget!(grad::AbstractVector, hyp::AbstractVector)
+        ltarget_and_dltarget!(grad::AbstractVector, hyp::AbstractVector)
     end
 
     xinit = get_params(gp; params_kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,17 +5,17 @@
 Create a matrix by applying function `f` to each pair of columns of input matrices
 `X` and `Y`.
 """
-function map_column_pairs(f, X::MatF64, Y::MatF64)
+function map_column_pairs(f, X::MatF64, Y::AbstractArray{T, 2}) where T
     nobs1 = size(X,2)
     nobs2 = size(Y,2)
-    D = Array{Float64}(undef, nobs1, nobs2)
+    D = Array{T}(undef, nobs1, nobs2)
     map_column_pairs!(D, f, X, Y)
     return D
 end
 
-function map_column_pairs(f, X::MatF64)
+function map_column_pairs(f, X::AbstractArray{T, 2}) where T
     dim, nobsv = size(X)
-    D = Array{Float64}(undef, nobsv, nobsv)
+    D = Array{T}(undef, nobsv, nobsv)
     for i in 1:nobsv
         for j in 1:i
             @inbounds D[i,j] = f(X[:,i], X[:,j])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,17 +5,17 @@
 Create a matrix by applying function `f` to each pair of columns of input matrices
 `X` and `Y`.
 """
-function map_column_pairs(f, X::AbstractMatrix, Y::AbstractArray{T, 2}) where T
+function map_column_pairs(f, X::AbstractMatrix, Y::AbstractMatrix)
     nobs1 = size(X,2)
     nobs2 = size(Y,2)
-    D = Array{T}(undef, nobs1, nobs2)
+    D = Array{eltype(Y)}(undef, nobs1, nobs2)
     map_column_pairs!(D, f, X, Y)
     return D
 end
 
-function map_column_pairs(f, X::AbstractArray{T, 2}) where T
+function map_column_pairs(f, X::AbstractMatrix)
     dim, nobsv = size(X)
-    D = Array{T}(undef, nobsv, nobsv)
+    D = Array{eltype(X)}(undef, nobsv, nobsv)
     for i in 1:nobsv
         for j in 1:i
             @inbounds D[i,j] = f(X[:,i], X[:,j])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,7 +5,7 @@
 Create a matrix by applying function `f` to each pair of columns of input matrices
 `X` and `Y`.
 """
-function map_column_pairs(f, X::MatF64, Y::AbstractArray{T, 2}) where T
+function map_column_pairs(f, X::AbstractMatrix, Y::AbstractArray{T, 2}) where T
     nobs1 = size(X,2)
     nobs2 = size(Y,2)
     D = Array{T}(undef, nobs1, nobs2)
@@ -30,7 +30,7 @@ end
 
 Like [`map_column_pairs`](@ref), but stores the result in `D` rather than a new matrix.
 """
-function map_column_pairs!(D::MatF64, f, X::MatF64, Y::MatF64)
+function map_column_pairs!(D::AbstractMatrix, f, X::AbstractMatrix, Y::AbstractMatrix)
     dim, nobs1 = size(X)
     nobs2 = size(Y,2)
     dim == size(Y,1) || throw(ArgumentError("Input observation matrices must have consistent dimensions"))
@@ -44,7 +44,7 @@ function map_column_pairs!(D::MatF64, f, X::MatF64, Y::MatF64)
     return D
 end
 
-function map_column_pairs!(D::MatF64, f, X::MatF64)
+function map_column_pairs!(D::AbstractMatrix, f, X::AbstractMatrix)
     dim, nobsv = size(X)
     size(D,1) == nobsv || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)",
                                                        size(D,1), nobsv)))


### PR DESCRIPTION
These are the changes I made locally, to use ForwardDiff in the BayesianOptimization package.

One thing I was wondering was whether you want to keep the MatF64 and the VecF64 constants. I could also replace all instances with AbstractMatrix and AbstractVector.