### PR TITLE
fix forward diff for Bayesian optimization

### DIFF
--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -351,13 +351,17 @@ function _predict(gp::GPE, x::AbstractMatrix)
     mu = mean(gp.mean, x) + cK'*gp.alpha        # Predictive mean
     Lck = whiten!(gp.cK, cK)
     Sigma_raw = cov(gp.kernel, x, x, priordata)
-    Sigma_raw = Sigma_raw - Lck'Lck
-    # LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
-    # LinearAlgebra.copytri!(Sigma_raw, 'U')
+    subtract_Lck!(eltype(x), Sigma_raw, Lck)
     # Add jitter to get stable covariance
     m, chol = make_posdef!(Sigma_raw)
     return mu, PDMat(m, chol)
 end
+@inline function subtract_Lck!(::Any, Sigma_raw, Lck)
+    LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
+    LinearAlgebra.copytri!(Sigma_raw, 'U')
+end
+@inline subtract_Lck!(::Type{<:Dual}, Sigma_raw, Lck) = Sigma_raw .-= Lck'Lck
+
 
 #———————————————————————————————————————————————————————————
 # Sample from the GPE

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -351,16 +351,16 @@ function _predict(gp::GPE, x::AbstractMatrix)
     mu = mean(gp.mean, x) + cK'*gp.alpha        # Predictive mean
     Lck = whiten!(gp.cK, cK)
     Sigma_raw = cov(gp.kernel, x, x, priordata)
-    subtract_Lck!(eltype(x), Sigma_raw, Lck)
+    subtract_Lck!(Sigma_raw, Lck)
     # Add jitter to get stable covariance
     m, chol = make_posdef!(Sigma_raw)
     return mu, PDMat(m, chol)
 end
-@inline function subtract_Lck!(::Any, Sigma_raw, Lck)
+@inline function subtract_Lck!(Sigma_raw::AbstractArray{Float64}, Lck::AbstractArray{Float64})
     LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
     LinearAlgebra.copytri!(Sigma_raw, 'U')
 end
-@inline subtract_Lck!(::Type{<:Dual}, Sigma_raw, Lck) = Sigma_raw .-= Lck'Lck
+@inline subtract_Lck!(Sigma_raw, Lck) = Sigma_raw .-= Lck'Lck
 
 
 #———————————————————————————————————————————————————————————

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -351,9 +351,9 @@ function _predict(gp::GPE, x::AbstractMatrix)
     mu = mean(gp.mean, x) + cK'*gp.alpha        # Predictive mean
     Lck = whiten!(gp.cK, cK)
     Sigma_raw = cov(gp.kernel, x, x, priordata)
-    # Sigma_raw = Sigma_raw - Lck'Lck
-    LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
-    LinearAlgebra.copytri!(Sigma_raw, 'U')
+    Sigma_raw = Sigma_raw - Lck'Lck
+    # LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
+    # LinearAlgebra.copytri!(Sigma_raw, 'U')
     # Add jitter to get stable covariance
     m, chol = make_posdef!(Sigma_raw)
     return mu, PDMat(m, chol)

--- a/src/kernels/distance.jl
+++ b/src/kernels/distance.jl
@@ -64,7 +64,7 @@ end
 @inline distij(dist::Euclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X,i,j,dim)
 @inline function distij(dist::Euclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
     if X1 === X2 && i == j
-        eltype(X2)(0)
+        zero(eltype(X2))
     else
         √_SqEuclidean_ij(X1,X2,i,j,dim)
     end
@@ -99,7 +99,7 @@ end
 @inline distij(dist::WeightedEuclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
 @inline function distij(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
     if X1 === X2 && i == j
-        eltype(X2)(0)
+        zero(eltype(X2))
     else
         √_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
     end

--- a/src/kernels/distance.jl
+++ b/src/kernels/distance.jl
@@ -5,7 +5,7 @@ distance(k::Stationary, X::AbstractMatrix, data::EmptyData) = distance(k, X)
 distance(k::Isotropic, X::AbstractMatrix, data::IsotropicData) = data.R
 function distance(k::Stationary, X::AbstractMatrix)
     nobsv = size(X, 2)
-    return distance!(Matrix{Float64}(undef, nobsv, nobsv), metric(k), X)
+    return distance!(Matrix{eltype(X)}(undef, nobsv, nobsv), metric(k), X)
 end
 distance!(dist::AbstractMatrix, k::Stationary, X::AbstractMatrix) = distance!(dist, metric(k), X)
 function distance!(dist::AbstractMatrix, m::PreMetric, X::AbstractMatrix)
@@ -21,7 +21,7 @@ end
 function distance(k::Stationary, X::AbstractMatrix, Y::AbstractMatrix)
     nobsx = size(X, 2)
     nobsy = size(Y, 2)
-    return distance!(Matrix{Float64}(undef, nobsx, nobsy), metric(k), X, Y)
+    return distance!(Matrix{eltype(Y)}(undef, nobsx, nobsy), metric(k), X, Y)
 end
 distance!(dist::AbstractMatrix, k::Stationary, X::AbstractMatrix, Y::AbstractMatrix) = distance!(dist, metric(k), X, Y)
 function distance!(dist::AbstractMatrix, m::PreMetric, X::AbstractMatrix, Y::AbstractMatrix)

--- a/src/kernels/distance.jl
+++ b/src/kernels/distance.jl
@@ -62,7 +62,13 @@ end
 
 # Euclidean
 @inline distij(dist::Euclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X,i,j,dim)
-@inline distij(dist::Euclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=√_SqEuclidean_ij(X1,X2,i,j,dim)
+@inline function distij(dist::Euclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
+    if X1 === X2 && i == j
+        eltype(X2)(0)
+    else
+        √_SqEuclidean_ij(X1,X2,i,j,dim)
+    end
+end
 
 @inline _WeightedSqEuclidean_ijk(weights::AbstractVector,X::AbstractMatrix,i::Int,j::Int,k::Int)=(X[k,i]-X[k,j])^2*weights[k]
 @inline _WeightedSqEuclidean_ijk(weights::AbstractVector,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=(X1[k,i]-X2[k,j])^2*weights[k]
@@ -91,4 +97,10 @@ end
 @inline dist2ijk(dist::WeightedEuclidean,X::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X,i,j,k)
 @inline dist2ijk(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,k::Int)=_WeightedSqEuclidean_ijk(dist.weights,X1,X2,i,j,k)
 @inline distij(dist::WeightedEuclidean,X::AbstractMatrix,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X,i,j,dim)
-@inline distij(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)=√_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
+@inline function distij(dist::WeightedEuclidean,X1::AbstractMatrix,X2::AbstractMatrix,i::Int,j::Int,dim::Int)
+    if X1 === X2 && i == j
+        eltype(X2)(0)
+    else
+        √_WeightedSqEuclidean_ij(dist.weights,X1,X2,i,j,dim)
+    end
+end

--- a/src/kernels/fixed_kernel.jl
+++ b/src/kernels/fixed_kernel.jl
@@ -1,6 +1,6 @@
 struct FixedKernel{K<:Kernel, NFREE} <: Kernel
     kernel::K
-    free::SVector{NFREE, Int64}
+    free::SVector{NFREE, Int}
 end
 
 @deprecate FixedKern FixedKernel
@@ -17,7 +17,7 @@ num_params(k::FixedKernel{K,NFREE}) where {K,NFREE} = NFREE
 # convenience functions to fix a parameter
 function FixedKernel(k::Kernel, free::AbstractVector{<:Int})
     npars = length(free)
-    sfree = SVector{npars, Int64}(free)
+    sfree = SVector{npars, Int}(free)
     return FixedKernel(k, sfree)
 end
 function fix(k::Kernel, par::Symbol)

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -30,7 +30,7 @@ each column is an observation.
 """
 function cov(k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix, kerneldata::KernelData=EmptyData())
     n1, n2 = size(X₁, 2), size(X₂, 2)
-    cK = Array{eltype(X₂)}(undef, n1, n2)
+    cK = Array{promote_type(eltype(X₁), eltype(X₂))}(undef, n1, n2)
     cov!(cK, k, X₁, X₂, kerneldata)
 end
 

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -30,7 +30,7 @@ each column is an observation.
 """
 function cov(k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix, kerneldata::KernelData=EmptyData())
     n1, n2 = size(X₁, 2), size(X₂, 2)
-    cK = Array{eltype(X₁)}(undef, n1, n2)
+    cK = Array{eltype(X₂)}(undef, n1, n2)
     cov!(cK, k, X₁, X₂, kerneldata)
 end
 
@@ -88,7 +88,7 @@ function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData
 end
 function cov(k::Kernel, X::AbstractMatrix, data::KernelData)
     dim, nobsv = size(X)
-    cK = Array{Float64}(undef, nobsv, nobsv)
+    cK = Array{eltype(X)}(undef, nobsv, nobsv)
     cov!(cK, k, X, data)
 end
 
@@ -148,7 +148,7 @@ grad_stack(k::Kernel, X::AbstractMatrix) = grad_stack(k, X, KernelData(k, X, X))
 
 function grad_stack(k::Kernel, X::AbstractMatrix, data::KernelData)
     nobs = size(X, 2)
-    stack = Array{Float64}(undef, nobs, nobs, num_params(k))
+    stack = Array{eltype(X)}(undef, nobs, nobs, num_params(k))
     grad_stack!(stack, k, X, data)
 end
 

--- a/src/kernels/lin_ard.jl
+++ b/src/kernels/lin_ard.jl
@@ -34,7 +34,7 @@ function KernelData(k::LinArd, X1::AbstractMatrix, X2::AbstractMatrix)
     dim2, nobs2 = size(X2)
 	@assert dim1==dim2
 	dim = dim1
-    XtX_d = Array{Float64}(undef, nobs1, nobs2, dim)
+    XtX_d = Array{eltype(X2)}(undef, nobs1, nobs2, dim)
     @inbounds @simd for d in 1:dim
         for i in 1:nobs1
             for j in 1:nobs2
@@ -60,7 +60,7 @@ function cov!(cK::AbstractMatrix, lin::LinArd, X::AbstractMatrix, data::LinArdDa
 end
 function cov(lin::LinArd, X::AbstractMatrix, data::LinArdData)
     nobs = size(X,2)
-    K = Array{Float64}(undef, nobs, nobs)
+    K = Array{eltype(X)}(undef, nobs, nobs)
     cov!(K, lin, X, data)
 end
 @inline @inbounds function cov_ij(lin::LinArd, X1::AbstractMatrix, X2::AbstractMatrix, data::LinArdData, i::Int, j::Int, dim::Int)

--- a/src/kernels/masked_kernel.jl
+++ b/src/kernels/masked_kernel.jl
@@ -12,13 +12,13 @@ active dimensions.
 """
 struct Masked{K<:Kernel, DIM} <: Kernel
     kernel::K
-    active_dims::SVector{DIM, Int64}
+    active_dims::SVector{DIM, Int}
 end
 num_dims(masked::Masked{K, DIM}) where {K, DIM} = DIM
 function Masked(kern::Kernel, active_dims::AbstractVector)
     dim = length(active_dims)
     K = typeof(kern)
-    return Masked{K,dim}(kern, SVector{dim, Int64}(active_dims))
+    return Masked{K,dim}(kern, SVector{dim, Int}(active_dims))
 end
 
 ################

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -133,7 +133,7 @@ function KernelData(k::StationaryARD, X1::AbstractMatrix, X2::AbstractMatrix)
 	dim2, n2 = size(X2)
 	@assert dim1 == dim2
 	dim = dim1
-	dist_stack = Array{Float64}(undef, n1, n2, dim)
+    dist_stack = Array{eltype(X2)}(undef, n1, n2, dim)
 	for d in 1:dim1
 		grad_ls = view(dist_stack, :, :, d)
 		distance!(grad_ls, SqEuclidean(), view(X1, d:d,:), view(X2, d:d,:))

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -133,8 +133,11 @@ function testkernel(kern::Kernel)
     
     @testset "predict gradient" begin
         gp = GPE(X, y, MeanConst(0.0), kern, -3.0)
-        f = x -> predict_y(gp, reshape(x, :, 1))[1][1]
-        g = ForwardDiff.gradient(f, rand(d))
+        f = x -> sum(predict_y(gp, reshape(x, :, 1)))[1]
+        z = rand(d)
+        autodiff_grad = ForwardDiff.gradient(f, z)
+        numer_grad = Calculus.gradient(f, z)
+        @test autodiff_grad ≈ numer_grad rtol = 1e-3 atol = 1e-3
     end
 end
 

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -1,6 +1,7 @@
 module TestKernels
 using GaussianProcesses, Calculus
 using Test, LinearAlgebra, Statistics, Random
+using ForwardDiff
 using GaussianProcesses: EmptyData, update_target_and_dtarget!, 
       cov_ij, dKij_dθp, dKij_dθ!, 
       get_params, set_params!, StationaryARD, WeightedEuclidean
@@ -128,6 +129,12 @@ function testkernel(kern::Kernel)
         update_target_and_dtarget!(gp_empty)
         update_target_and_dtarget!(gp)
         @test gp.dmll ≈ gp_empty.dmll rtol=1e-6 atol=1e-6
+    end
+    
+    @testset "predict gradient" begin
+        gp = GPE(X, y, MeanConst(0.0), kern, -3.0)
+        f = x -> predict_y(gp, reshape(x, :, 1))[1][1]
+        g = ForwardDiff.gradient(f, rand(d))
     end
 end
 


### PR DESCRIPTION
Hi @maximerischard 

With some of the newer changes I couldn't use `ForwardDiff` anymore in the acquisition function of `BayesianOptimization`. The fix required the right `eltype` in some functions ~but also going back to not use `BLAS.syrk!` in `_predict`~. Is this fine for you?