### PR TITLE
trial sparse approximations with subset of regressors implementation

### DIFF
--- a/src/GP.jl
+++ b/src/GP.jl
@@ -3,6 +3,49 @@
 abstract type GPBase end
 
 """
+    The abstract CovarianceStrategy type is for types that control how
+    the covariance matrices and their positive definite representation
+    are obtained or approximated. See SparseStrategy for examples.
+"""
+abstract type CovarianceStrategy end
+struct FullCovariance <: CovarianceStrategy end
+function alloc_cK(covstrat::CovarianceStrategy, nobs)
+    # create placeholder PDMat
+    m = Matrix{Float64}(undef, nobs, nobs)
+    chol = Matrix{Float64}(undef, nobs, nobs)
+    cK = PDMats.PDMat(m, Cholesky(chol, 'U', 0))
+    return cK
+end
+
+#===============================
+  Predictions
+================================#
+""" Compute predictions using the standard multivariate normal 
+    conditional distribution formulae.
+"""
+function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+                   kernel::Kernel, meanf::Mean, logNoise::Real,
+                   alpha::AbstractVector,
+                   covstrat::CovarianceStrategy, Ktrain::AbstractPDMat)
+    crossdata = KernelData(kernel, xtrain, xpred)
+    priordata = KernelData(kernel, xpred, xpred)
+    Kcross = cov(kernel, xtrain, xpred, crossdata)
+    mu = mean(meanf, xpred) + Kcross'*alpha # Predictive mean
+    Lck = whiten!(Ktrain, Kcross)
+    Sigma_raw = cov(kernel, xpred, xpred, priordata)
+    subtract_Lck!(Sigma_raw, Lck)
+    return mu, Sigma_raw
+    # Add jitter to get stable covariance
+    # m, chol = make_posdef!(Sigma_raw)
+    # return mu, PDMat(m, chol)
+end
+@inline function subtract_Lck!(Sigma_raw::AbstractArray{<:AbstractFloat}, Lck::AbstractArray{<:AbstractFloat})
+    LinearAlgebra.BLAS.syrk!('U', 'T', -1.0, Lck, 1.0, Sigma_raw)
+    LinearAlgebra.copytri!(Sigma_raw, 'U')
+end
+@inline subtract_Lck!(Sigma_raw, Lck) = Sigma_raw .-= Lck'Lck
+
+"""
     predict_f(gp::GPBase, X::Matrix{Float64}[; full_cov::Bool = false])
 
 Return posterior mean and variance of the Gaussian Process `gp` at specfic points which are
@@ -12,13 +55,13 @@ returned instead of only variances.
 function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
     size(x,1) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
     if full_cov
-        return _predict(gp, x)
+        return predict_full(gp, x)
     else
         ## Calculate prediction for each point independently
             μ = Array{eltype(x)}(undef, size(x,2))
             σ2 = similar(μ)
         for k in 1:size(x,2)
-            m, sig = _predict(gp, x[:,k:k])
+            m, sig = predict_full(gp, x[:,k:k])
             μ[k] = m[1]
             σ2[k] = max(diag(sig)[1], 0.0)
         end
@@ -26,8 +69,11 @@ function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
     end
 end
 
-# 1D Case for prediction
+# 1D Case for prediction of process
 predict_f(gp::GPBase, x::AbstractVector; full_cov::Bool=false) = predict_f(gp, x'; full_cov=full_cov)
+# 1D Case for prediction of observations
+predict_y(gp::GPBase, x::AbstractVector; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
+@deprecate predict predict_y
 
 wrap_cK(cK::PDMat, Σbuffer, chol::Cholesky) = PDMat(Σbuffer, chol)
 mat(cK::PDMat) = cK.mat

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -60,8 +60,8 @@ function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
         return predict_full(gp, x)
     else
         ## Calculate prediction for each point independently
-            μ = Array{eltype(x)}(undef, size(x,2))
-            σ2 = similar(μ)
+        μ = Array{eltype(x)}(undef, size(x,2))
+        σ2 = similar(μ)
         for k in 1:size(x,2)
             m, sig = predict_full(gp, x[:,k:k])
             μ[k] = m[1]
@@ -72,9 +72,9 @@ function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
 end
 
 # 1D Case for prediction of process
-predict_f(gp::GPBase, x::AbstractVector; full_cov::Bool=false) = predict_f(gp, x'; full_cov=full_cov)
+predict_f(gp::GPBase, x::AbstractVector, args...; kwargs...) = predict_f(gp, x', args...; kwargs...)
 # 1D Case for prediction of observations
-predict_y(gp::GPBase, x::AbstractVector; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
+predict_y(gp::GPBase, x::AbstractVector, args...; kwargs...) = predict_y(gp, x', args...; kwargs...)
 @deprecate predict predict_y
 
 wrap_cK(cK::PDMat, Σbuffer, chol::Cholesky) = PDMat(Σbuffer, chol)

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -24,7 +24,7 @@ end
     conditional distribution formulae.
 """
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
-                   kernel::Kernel, meanf::Mean, logNoise::Real,
+                   kernel::Kernel, meanf::Mean,
                    alpha::AbstractVector,
                    covstrat::CovarianceStrategy, Ktrain::AbstractPDMat)
     crossdata = KernelData(kernel, xtrain, xpred)

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -251,12 +251,15 @@ end
 function dmll_noise(gp::GPE, precomp::FullCovariancePrecompute, covstrat::CovarianceStrategy)
     return exp(2 * gp.logNoise) * tr(precomp.ααinvcKI)
 end
-function dmll_mean!(dmll::AbstractVector, gp::GPBase, precomp::AbstractGradientPrecompute)
-    Mgrads = grad_stack(gp.mean, gp.x)
-    for j in 1:num_params(gp.mean)
-        dmll[j] = dot(Mgrads[:,j], gp.alpha)
+function dmll_mean!(dmll::AbstractVector, meanf::Mean, x::AbstractMatrix, alpha::AbstractVector)
+    Mgrads = grad_stack(meanf, x)
+    for j in 1:num_params(meanf)
+        dmll[j] = dot(Mgrads[:,j], alpha)
     end
     return dmll
+end
+function dmll_mean!(dmll::AbstractVector, gp::GPBase, precomp::AbstractGradientPrecompute)
+    dmll_mean!(dmll, gp.mean, gp.x, gp.alpha)
 end
 
 """

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -369,7 +369,7 @@ end
 
 predict_full(gp::GPE, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, gp.y, gp.kernel, gp.mean, gp.alpha, gp.covstrat, gp.cK)
 """
-    predict_y(gp::GPE, x::Union{Vector{Float64},Matrix{Float64}}[; full_cov::Bool=false])
+    predict_full(gp::GPE, x::Union{Vector{Float64},Matrix{Float64}}[; full_cov::Bool=false])
 
 Return the predictive mean and variance of Gaussian Process `gp` at specfic points which
 are given as columns of matrix `x`. If `full_cov` is `true`, the full covariance matrix is

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -334,7 +334,8 @@ returned instead of only variances.
 function predict_y(gp::GPE, x::AbstractMatrix; full_cov::Bool=false)
     μ, σ2 = predict_f(gp, x; full_cov=full_cov)
     if full_cov
-        return μ, σ2 + ScalMat(gp.nobs, exp(2*gp.logNoise))
+        npred = size(x, 2)
+        return μ, σ2 + ScalMat(npred, exp(2*gp.logNoise))
     else
         return μ, σ2 .+ exp(2*gp.logNoise)
     end

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -367,7 +367,7 @@ end
 # Predict observations #
 #——————————————————————#
 
-predict_full(gp::GPE, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, gp.y, gp.kernel, gp.mean, gp.logNoise, gp.alpha, gp.covstrat, gp.cK)
+predict_full(gp::GPE, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, gp.y, gp.kernel, gp.mean, gp.alpha, gp.covstrat, gp.cK)
 """
     predict_y(gp::GPE, x::Union{Vector{Float64},Matrix{Float64}}[; full_cov::Bool=false])
 

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -213,7 +213,7 @@ function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, data::Ke
             dmll[iparam] += dK_buffer[iparam] * ααinvcKI[j, j] / 2.0
         end
         # off-diagonal
-        for i in 1:j-1
+        for i in j+1:nobs
             dKij_dθ!(dK_buffer, k, X, X, data, i, j, dim, nparams)
             @simd for iparam in 1:nparams
                 dmll[iparam] += dK_buffer[iparam] * ααinvcKI[i, j]

--- a/src/GPEelastic.jl
+++ b/src/GPEelastic.jl
@@ -1,6 +1,12 @@
 import Base.append!
+
+struct ElasticCov <: CovarianceStrategy
+    capacity::Int
+    stepsize::Int
+end
+
 append!(gp, x::AbstractVector, y::Float64) = append!(gp, reshape(x, :, 1), [y])
-function append!(gp::GPE{X,Y,M,K,P,D}, x::AbstractMatrix, y::AbstractVector) where {X,Y,M,K,P <: ElasticPDMat, D}
+function append!(gp::GPE{X,Y,M,K,CS,D,P}, x::AbstractMatrix, y::AbstractVector) where {X,Y,M,K,CS,D,P <: ElasticPDMat}
     size(x, 2) == length(y) || error("$(size(x, 2)) observations, but $(length(y)) targets.")
     newcov = [cov(gp.kernel, gp.x, x); cov(gp.kernel, x, x) + (exp(2*gp.logNoise) + eps())*I]
     append!(gp.data, gp.kernel, gp.x, x)
@@ -21,16 +27,22 @@ function ElasticGPE(dim; mean::Mean = MeanZero(), kernel = SE(0.0, 0.0),
     y = ElasticArray(Array{Float64}(undef, 0))
     ElasticGPE(x, y, mean, kernel, logNoise; kwargs...)
 end
-function ElasticGPE(x::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, 
-                    logNoise::Float64 = -2.0;
-                    capacity = 10^3, stepsize = 10^3)
-    data = ElasticKernelData(kernel, x, x, capacity = capacity, stepsize = stepsize)
-    nobs = length(y)
+function alloc_cK(covstrat::ElasticCov, nobs)
     # create placeholder PDMat
     m    = Matrix{Float64}(undef, nobs, nobs)
     chol = Matrix{Float64}(undef, nobs, nobs)
-    cK = ElasticPDMat(m, Cholesky(chol, :U, 0), capacity=capacity, stepsize=stepsize)
-    gp = GPE(ElasticArray(x), ElasticArray(y), mean, kernel, logNoise, data, cK)
+    cK = ElasticPDMat(m, Cholesky(chol, :U, 0), capacity=covstrat.capacity, stepsize=covstrat.stepsize)
+    return cK
+end
+function ElasticGPE(x::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, 
+                    logNoise::Float64 = -2.0;
+                    capacity = 10^3, stepsize = 10^3)
+    data = ElasticKernelData(kernel, x, x, capacity=capacity, stepsize=stepsize)
+    nobs = length(y)
+    # create placeholder PDMat
+    covstrat = ElasticCov(capacity, stepsize)
+    cK = alloc_cK(covstrat, nobs)
+    gp = GPE(ElasticArray(x), ElasticArray(y), mean, kernel, logNoise, covstrat, data, cK)
     initialise_target!(gp)
 end
 
@@ -43,6 +55,10 @@ function prepareappend!(kd, Xnew)
     end
     kd, dim, nobs, nobs_new
 end
+
+#===========================
+    Elastic Kernel Data
+===========================#
 
 function ElasticKernelData(k::Isotropic, X1::AbstractMatrix, X2::AbstractMatrix; capacity = 10^3, stepsize = 10^3)
     @assert X1==X2 # TODO: extend to X1 != X2

--- a/src/GPEelastic.jl
+++ b/src/GPEelastic.jl
@@ -1,8 +1,12 @@
 import Base.append!
 
-struct ElasticCov <: CovarianceStrategy
+struct ElasticCovStrat <: CovarianceStrategy
     capacity::Int
     stepsize::Int
+end
+function init_precompute(covstrat::ElasticCovStrat, X, y, k)
+    nobs = size(X, 2)
+    FullCovariancePrecompute(nobs)
 end
 
 append!(gp, x::AbstractVector, y::Float64) = append!(gp, reshape(x, :, 1), [y])
@@ -28,7 +32,7 @@ function ElasticGPE(dim; mean::Mean = MeanZero(), kernel = SE(0.0, 0.0),
     y = ElasticArray(Array{Float64}(undef, 0))
     ElasticGPE(x, y, mean, kernel, logNoise; kwargs...)
 end
-function alloc_cK(covstrat::ElasticCov, nobs)
+function alloc_cK(covstrat::ElasticCovStrat, nobs)
     # create placeholder PDMat
     m    = Matrix{Float64}(undef, nobs, nobs)
     chol = Matrix{Float64}(undef, nobs, nobs)
@@ -41,7 +45,7 @@ function ElasticGPE(x::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Ke
     data = ElasticKernelData(kernel, x, x, capacity=capacity, stepsize=stepsize)
     nobs = length(y)
     # create placeholder PDMat
-    covstrat = ElasticCov(capacity, stepsize)
+    covstrat = ElasticCovStrat(capacity, stepsize)
     cK = alloc_cK(covstrat, nobs)
     gp = GPE(ElasticArray(x), ElasticArray(y), mean, kernel, logNoise, covstrat, data, cK)
     initialise_target!(gp)

--- a/src/GPEelastic.jl
+++ b/src/GPEelastic.jl
@@ -17,6 +17,7 @@ function append!(gp::GPE{X,Y,M,K,CS,D,P}, x::AbstractMatrix, y::AbstractVector) 
     update_target!(gp, kern = false, noise = false)
 end
 
+LinearAlgebra.ldiv!(cK::ElasticPDMat, x) = ldiv!(cK.chol, x)
 wrap_cK(cK::ElasticPDMat, Σbuffer, chol::Cholesky) = cK
 mat(cK::ElasticPDMat) = view(cK.mat)
 cholfactors(cK::ElasticPDMat) = view(cK.chol).factors

--- a/src/GPMC.jl
+++ b/src/GPMC.jl
@@ -267,6 +267,7 @@ function update_target_and_dtarget!(gp::GPMC; kwargs...)
 end
 
 
+predict_full(gp::GPMC, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, xp.y, gp.kernel, gp.mean, -Inf, gp.alpha, gp.covstrat, gp.cK)
 """
     predict_y(gp::GPMC, x::Union{Vector{Float64},Matrix{Float64}}[; full_cov::Bool=false])
 
@@ -277,21 +278,6 @@ returned instead of only variances.
 function predict_y(gp::GPMC, x::AbstractMatrix; full_cov::Bool=false)
     μ, σ2 = predict_f(gp, x; full_cov=full_cov)
     return predict_obs(gp.lik, μ, σ2)
-end
-
-# 1D Case for prediction
-predict_y(gp::GPMC, x::AbstractVector; full_cov::Bool=false) = predict_y(gp, x'; full_cov=full_cov)
-
-
-## compute predictions
-function _predict(gp::GPMC, x::AbstractMatrix)
-    cK = cov(gp.kernel, gp.x, x)
-    Lck = whiten(gp.cK, cK)
-    fmu =  mean(gp.mean,x) + Lck'gp.v     # Predictive mean
-    Sigma_raw = cov(gp.kernel, x) - Lck'Lck # Predictive covariance
-    # Add jitter to get stable covariance
-    Σ, chol = make_posdef!(Sigma_raw)
-    return fmu, Σ
 end
 
 

--- a/src/GPMC.jl
+++ b/src/GPMC.jl
@@ -92,7 +92,7 @@ Initialise the log-likelihood of Gaussian process `gp`.
 function initialise_ll!(gp::GPMC)
     # log p(Y|v,θ)
     gp.μ = mean(gp.mean,gp.x)
-    Σ = cov(gp.kernel, gp.x, gp.data)
+    Σ = cov(gp.kernel, gp.x, gp.x, gp.data)
     gp.cK = PDMat(Σ + 1e-6*I)
     F = unwhiten(gp.cK,gp.v) + gp.μ
     gp.ll = sum(log_dens(gp.lik,F,gp.y)) #Log-likelihood
@@ -107,7 +107,7 @@ Update the covariance matrix and its Cholesky decomposition of Gaussian process 
 function update_cK!(gp::GPMC)
     old_cK = gp.cK
     Σbuffer = old_cK.mat
-    cov!(Σbuffer, gp.kernel, gp.x, gp.data)
+    cov!(Σbuffer, gp.kernel, gp.x, gp.x, gp.data)
     for i in 1:gp.nobs
         Σbuffer[i,i] += 1e-6 # no logNoise for GPMC
     end
@@ -289,7 +289,7 @@ function Random.rand!(gp::GPMC, x::AbstractMatrix, A::DenseMatrix)
     if gp.nobs == 0
         # Prior mean and covariance
         μ = mean(gp.mean, x);
-        Σraw = cov(gp.kernel, x);
+        Σraw = cov(gp.kernel, x, x);
         # Add jitter to get stable covariance
         Σ, chol = make_posdef!(Σraw)
     else

--- a/src/GPMC.jl
+++ b/src/GPMC.jl
@@ -302,7 +302,7 @@ function update_target_and_dtarget!(gp::GPMC; kwargs...)
 end
 
 
-predict_full(gp::GPMC, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, xp.y, gp.kernel, gp.mean, -Inf, gp.alpha, gp.covstrat, gp.cK)
+predict_full(gp::GPMC, xpred::AbstractMatrix) = predictMVN(xpred, gp.x, xp.y, gp.kernel, gp.mean, gp.alpha, gp.covstrat, gp.cK)
 """
     predict_y(gp::GPMC, x::Union{Vector{Float64},Matrix{Float64}}[; full_cov::Bool=false])
 

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -6,6 +6,8 @@ using StatsFuns, SpecialFunctions
 
 using LinearAlgebra, Printf, Random, Statistics
 import Statistics: mean, cov
+import Base: size
+import PDMats: dim, Matrix, diag, pdadd!, *, \, inv, logdet, eigmax, eigmin, whiten!, unwhiten!, quad, quad!, invquad, invquad!, X_A_Xt, Xt_A_X, X_invA_Xt, Xt_invA_X
 
 # Functions that should be available to package
 # users should be explicitly exported here
@@ -37,6 +39,7 @@ include("mcmc.jl")
 include("optimize.jl")
 include("crossvalidation.jl")
 include("plot.jl")
+include("sparse/sparseGP.jl")
 
 # ScikitLearnBase, which is a skeleton package.
 include("ScikitLearn.jl")

--- a/src/crossvalidation.jl
+++ b/src/crossvalidation.jl
@@ -77,7 +77,7 @@ function dlogpdθ_LOO_kern!(∂logp∂θ::AbstractVector{<:Real}, invΣ::PDMat, 
     # ∂σ∂θ = Matrix{Float64}(undef, nobs, dim)
     Zj = Matrix{Float64}(undef, nobs, nobs)
     for j in 1:dim
-        grad_slice!(Zj, kernel, x, data, j)
+        grad_slice!(Zj, kernel, x, x, data, j)
         Zj = invΣ.mat * Zj
         # ldiv!(Σ, Zj)
 
@@ -268,7 +268,7 @@ function dlogpdθ_CVfold_kern!(∂logp∂θ::AbstractVector{<:Real}, invΣ::PDMa
     buffer1 = Matrix{Float64}(undef, nobs, nobs)
     buffer2 = Matrix{Float64}(undef, nobs, nobs)
     for j in 1:dim
-        grad_slice!(buffer2, kernel, x, data, j)
+        grad_slice!(buffer2, kernel, x, x, data, j)
         mul!(buffer1, mat(invΣ), buffer2)
         Zj = buffer1
         Zjα = Zj*alpha

--- a/src/kernels/autodiff.jl
+++ b/src/kernels/autodiff.jl
@@ -66,40 +66,20 @@ end
 @inline cov(ad::ADkernel, r::Real) = cov(raw(ad), r)
 @inline cov(ad::ADkernel, x1::AbstractVector, x2::AbstractVector) = cov(raw(ad), x1, x2)
 @inline cov_ij(ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int) = cov_ij(raw(ad), X1, X2, data, i, j, dim)
-@inline cov_ij(ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(raw(ad), X1, X2, i, j, dim)
 
 KernelData(ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix) = KernelData(raw(ad), X1, X2)
 kernel_data_key(ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix) = kernel_data_key(raw(ad), X1, X2)
 
-@inline function dKij_dθ!(dK::AbstractVector, ad::ADkernel, X::AbstractMatrix,
+@inline function dKij_dθ!(dK::AbstractVector, ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData,
                   i::Int, j::Int, dim::Int, npars::Int)
     seed!(ad)
-    k_eval = cov_ij(dual(ad), X, X, i, j, dim)
+    k_eval = cov_ij(dual(ad), X1, X2, data, i, j, dim)
     copyto!(dK, partials(k_eval))
     return dK
 end
-@inline function dKij_dθ!(dK::AbstractVector, ad::ADkernel, X::AbstractMatrix, data::EmptyData,
-                  i::Int, j::Int, dim::Int, npars::Int)
-    dKij_dθ!(dK, ad, X, i, j, dim, npars)
-end
-@inline function dKij_dθ!(dK::AbstractVector, ad::ADkernel, X::AbstractMatrix, data::KernelData,
-                  i::Int, j::Int, dim::Int, npars::Int)
+@inline function dKij_dθp(ad::ADkernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, p::Int, dim::Int)
     seed!(ad)
-    k_eval = cov_ij(dual(ad), X, X, data, i, j, dim)
-    copyto!(dK, partials(k_eval))
-    return dK
-end
-@inline function dKij_dθp(ad::ADkernel, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
-    seed!(ad)
-    k_eval = cov_ij(dual(ad), X, X, i, j, dim)
-    return partials(k_eval)[p]
-end
-@inline function dKij_dθp(ad::ADkernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
-    dKij_dθp(ad, X, i, j, p, dim)
-end
-@inline function dKij_dθp(ad::ADkernel, X::AbstractMatrix, data::KernelData, i::Int, j::Int, p::Int, dim::Int)
-    seed!(ad)
-    k_eval = cov_ij(dual(ad), X, X, data, i, j, dim)
+    k_eval = cov_ij(dual(ad), X1, X2, data, i, j, dim)
     return partials(k_eval)[p]
 end
 

--- a/src/kernels/const.jl
+++ b/src/kernels/const.jl
@@ -36,16 +36,9 @@ function cov(cons::Const, x::AbstractVector, y::AbstractVector)
 end
 
 @inline dk_dlσ(cons::Const) = 2.0*cov(cons)
-@inline function dKij_dθp(cons::Const, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(cons::Const, X1, X2, i::Int, j::Int, p::Int, dim::Int)
     if p == 1
         return dk_dlσ(cons)
-    else
-        return NaN
-    end
-end
-@inline function dKij_dθp(cons::Const, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
-    if p == 1
-        return dKij_dθp(cons, X, i, j, p, dim)
     else
         return NaN
     end

--- a/src/kernels/distance.jl
+++ b/src/kernels/distance.jl
@@ -4,13 +4,13 @@ distance(k::Stationary, x::AbstractVector, y::AbstractVector) = evaluate(metric(
 distance(k::Stationary, X::AbstractMatrix, data::EmptyData) = distance(k, X)
 distance(k::Isotropic, X::AbstractMatrix, data::IsotropicData) = data.R
 function distance(k::Stationary, X::AbstractMatrix)
-    nobsv = size(X, 2)
-    return distance!(Matrix{eltype(X)}(undef, nobsv, nobsv), metric(k), X)
+    nobs = size(X, 2)
+    return distance!(Matrix{eltype(X)}(undef, nobs, nobs), metric(k), X)
 end
 distance!(dist::AbstractMatrix, k::Stationary, X::AbstractMatrix) = distance!(dist, metric(k), X)
 function distance!(dist::AbstractMatrix, m::PreMetric, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    @inbounds @simd for i in 1:nobsv
+    dim, nobs = size(X)
+    @inbounds @simd for i in 1:nobs
         dist[i,i] = 0.0
         for j in 1:i-1
             dist[i,j] = dist[j,i] = distij(m, X, i, j, dim)

--- a/src/kernels/fixed_kernel.jl
+++ b/src/kernels/fixed_kernel.jl
@@ -58,26 +58,15 @@ function free(k::FixedKernel, par::Symbol)
     return FixedKernel(k.kernel, free)
 end
 
-function grad_slice!(dK::AbstractMatrix, k::FixedKernel, X::AbstractMatrix, data::KernelData, p::Int)
-    return grad_slice!(dK, k.kernel, X, data, k.free[p])
+function grad_slice!(dK::AbstractMatrix, k::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, p::Int)
+    return grad_slice!(dK, k.kernel, X1, X2, data, k.free[p])
 end
-function grad_slice!(dK::AbstractMatrix, k::FixedKernel, X::AbstractMatrix, data::EmptyData, p::Int)
-    return grad_slice!(dK, k.kernel, X, data, k.free[p])
-end
-@inline function dKij_dθp(fk::FixedKernel,X::AbstractMatrix,i::Int,j::Int,p::Int,dim::Int)
-    return dKij_dθp(fk.kernel, X, i, j, fk.free[p], dim)
-end
-@inline function dKij_dθp(fk::FixedKernel,X::AbstractMatrix,data::EmptyData,i::Int,j::Int,p::Int,dim::Int)
-    return dKij_dθp(fk, X, i, j, p, dim)
-end
-@inline function dKij_dθp(fk::FixedKernel,X::AbstractMatrix,data::KernelData,i::Int,j::Int,p::Int,dim::Int)
-    return dKij_dθp(fk.kernel, X, data, i, j, fk.free[p], dim)
+@inline function dKij_dθp(fk::FixedKernel,X1::AbstractMatrix, X2::AbstractMatrix,data::KernelData,i::Int,j::Int,p::Int,dim::Int)
+    return dKij_dθp(fk.kernel, X1, X2, data, i, j, fk.free[p], dim)
 end
 
 # delegate everything else to the wrapped kernel
-@inline cov_ij(fk::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X1, X2, i, j, dim)
 @inline cov_ij(fk::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int) = cov_ij(fk.kernel, X1, X2, data, i, j, dim)
-@inline cov_ij(fk::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(fk, X1, X2, i, j, dim)
 cov(fk::FixedKernel, x::AbstractVector, y::AbstractVector) = cov(fk.kernel, x, y)
 KernelData(fk::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix) = KernelData(fk.kernel, X1, X2)
 kernel_data_key(fk::FixedKernel, X1::AbstractMatrix, X2::AbstractMatrix) = kernel_data_key(fk.kernel, X1, X2)

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -23,61 +23,22 @@ KernelData(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix) = EmptyData()
 kernel_data_key(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix) = "EmptyData"
 
 """
-    cov(k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix)
+    cov(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix)
 
-Create covariance matrix from kernel `k` and matrices of observations `X₁` and `X₂`, where
+Create covariance matrix from kernel `k` and matrices of observations `X1` and `X2`, where
 each column is an observation.
 """
-function cov(k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix, kerneldata::KernelData=EmptyData())
-    n1, n2 = size(X₁, 2), size(X₂, 2)
-    cK = Array{promote_type(eltype(X₁), eltype(X₂))}(undef, n1, n2)
-    cov!(cK, k, X₁, X₂, kerneldata)
+function cov(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData=EmptyData())
+    dim1, nobs1 = size(X1)
+    dim2, nobs2 = size(X2)
+    dim1==dim2 || throw(ArgumentError("X1 and X2 must have same dimension"))
+    cK = Array{promote_type(eltype(X1), eltype(X2))}(undef, nobs1, nobs2)
+    cov!(cK, k, X1, X2, data)
 end
 
-"""
-    cov!(cK::AbstractMatrix, k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix)
-
-Like [`cov(k, X₁, X₂)`](@ref), but stores the result in `cK` rather than a new matrix.
-"""
-function cov!(cK::AbstractMatrix, k::Kernel, X₁::AbstractMatrix, X₂::AbstractMatrix, kerneldata::KernelData=EmptyData())
-    n1, n2 = size(X₁, 2), size(X₂, 2)
-    dim = size(X₁, 1)
-    @inbounds for i in 1:n1
-        for j in 1:n2
-            cK[i,j] = cov_ij(k, X₁, X₂, kerneldata, i, j, dim)
-        end
-    end
-    return cK
-end
-
-"""
-    cov(k::Kernel, X::AbstractMatrix[, data::KernelData = KernelData(k, X, X)])
-
-Create covariance function from kernel `k`, matrix of observations `X`, where each column is
-an observation, and kernel data `data` constructed from input observations.
-"""
-cov(k::Kernel, X::AbstractMatrix, data::EmptyData) = cov(k, X)
-cov!(k::Kernel, X::AbstractMatrix, data::EmptyData) = cov!(cK, k, X)
-
-function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    @inbounds for j in 1:nobsv
-        cK[j,j] = cov_ij(k, X, X, j, j, dim)
-        for i in 1:j-1
-            cK[i,j] = cov_ij(k, X, X, i, j, dim)
-            cK[j,i] = cK[i,j]
-        end
-    end
-    return cK
-end
-function cov(k::Kernel, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    cK = Array{eltype(X)}(undef, nobsv, nobsv)
-    cov!(cK, k, X)
-end
-function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData)
-    dim, nobsv = size(X)
-    @inbounds for j in 1:nobsv
+function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData=EmptyData())
+    dim, nobs = size(X)
+    @inbounds for j in 1:nobs
         cK[j,j] = cov_ij(k, X, X, data, j, j, dim)
         for i in 1:j-1
             cK[i,j] = cov_ij(k, X, X, data, i, j, dim)
@@ -86,73 +47,95 @@ function cov!(cK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData
     end
     return cK
 end
-function cov(k::Kernel, X::AbstractMatrix, data::KernelData)
-    dim, nobsv = size(X)
-    cK = Array{eltype(X)}(undef, nobsv, nobsv)
-    cov!(cK, k, X, data)
+"""
+    cov!(cK::AbstractMatrix, k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix)
+
+Like [`cov(k, X1, X2)`](@ref), but stores the result in `cK` rather than a new matrix.
+"""
+function cov!(cK::AbstractMatrix, k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData=EmptyData())
+    if X1 === X2
+        return cov!(cK, k, X1, data)
+    end
+    n1, n2 = size(X1, 2), size(X2, 2)
+    dim = size(X1, 1)
+    @inbounds for i in 1:n1
+        for j in 1:n2
+            cK[i,j] = cov_ij(k, X1, X2, data, i, j, dim)
+        end
+    end
+    return cK
 end
 
+"""
+    cov(k::Kernel, X::AbstractMatrix[, data::KernelData = EmptyData()])
+
+Create covariance matrix from kernel `k`, matrix of observations `X`, where each column is
+an observation, and kernel data `data` constructed from input observations.
+"""
+cov(k::Kernel, X::AbstractMatrix, data::KernelData=EmptyData()) = cov(k, X, X, data)
+
+
 @inline cov_ij(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int) = cov(k, @view(X1[:,i]), @view(X2[:,j]))
-@inline cov_ij(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(k, X1, X2, i, j, dim)
+# the default is to drop the KernelData
+@inline cov_ij(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int) = cov_ij(k, X1, X2, i, j, dim)
 
 ############################
 ##### Kernel Gradients #####
 ############################
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Kernel, X::AbstractMatrix, 
-                                    i::Int, j::Int, dim::Int, npars::Int)
-    for p in 1:npars
-        dK[p] = dKij_dθp(kern, X, i, j, p, dim)
-    end
-end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Kernel, X::AbstractMatrix, data::KernelData, 
-                                    i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Kernel, X1::AbstractMatrix, X2::AbstractMatrix,
+                                    data::KernelData, i::Int, j::Int, dim::Int, npars::Int)
     for iparam in 1:npars
-        dK[iparam] = dKij_dθp(kern, X, data, i, j, iparam, dim)
+        dK[iparam] = dKij_dθp(kern, X1, X2, data, i, j, iparam, dim)
     end
 end
 
 function grad_slice!(dK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::KernelData, p::Int)
-    dim = size(X,1)
-    @inbounds for j in 1:size(X, 2)
-        @simd for i in 1:j
-            dK[i,j] = dKij_dθp(k,X,data,i,j,p,dim)
+    dim, nobs = size(X)
+    @inbounds for j in 1:nobs
+        dK[j,j] = dKij_dθp(k,X,X,data,j,j,p,dim)
+        @simd for i in 1:(j-1)
+            dK[i,j] = dKij_dθp(k,X,X,data,i,j,p,dim)
             dK[j,i] = dK[i,j]
         end
     end
     return dK
 end
-
-function grad_slice!(dK::AbstractMatrix, k::Kernel, X::AbstractMatrix, data::EmptyData, p::Int)
-    dim = size(X, 1)
-    @inbounds for j in 1:size(X, 2)
-        @simd for i in 1:j
-            dK[i,j] = dKij_dθp(k,X,i,j,p,dim)
-            dK[j,i] = dK[i,j]
+function grad_slice!(dK::AbstractMatrix, k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, p::Int)
+    if X1 === X2
+        return grad_slice!(dK, k, X1, data, p)
+    end
+    dim = size(X1,1)
+    @inbounds for j in 1:size(X1, 2)
+        @simd for i in 1:size(X2, 2)
+            dK[i,j] = dKij_dθp(k,X1,X2,data,i,j,p,dim)
         end
     end
     return dK
 end
 
 # Calculates the stack [dk / dθᵢ] of kernel matrix gradients
-function grad_stack!(stack::AbstractArray, k::Kernel, X::AbstractMatrix, data::KernelData)
+function grad_stack!(stack::AbstractArray, k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData)
     @inbounds for p in 1:num_params(k)
-        grad_slice!(view(stack, :, :, p), k, X, data, p)
+        grad_slice!(view(stack, :, :, p), k, X1, X2, data, p)
     end
     stack
 end
 
-grad_stack!(stack::AbstractArray, k::Kernel, X::AbstractMatrix) =
-    grad_stack!(stack, k, X, KernelData(k, X, X))
+grad_stack!(stack::AbstractArray, k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix) =
+    grad_stack!(stack, k, X1, X2, KernelData(k, X1, X2))
 
-grad_stack(k::Kernel, X::AbstractMatrix) = grad_stack(k, X, KernelData(k, X, X))
+grad_stack(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix) = grad_stack(k, X1, X2, KernelData(k, X1, X2))
 
-function grad_stack(k::Kernel, X::AbstractMatrix, data::KernelData)
-    nobs = size(X, 2)
-    stack = Array{eltype(X)}(undef, nobs, nobs, num_params(k))
-    grad_stack!(stack, k, X, data)
+function grad_stack(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData)
+    nobs1 = size(X1, 2)
+    nobs2 = size(X2, 2)
+    stack = Array{eltype(X)}(undef, nobs1, nobs2, num_params(k))
+    grad_stack!(stack, k, X1, X2, data)
 end
 
-@inline dKij_dθp(k::Kernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int) = dKij_dθp(k, X, i, j, p, dim)
+@inline function dKij_dθp(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, p::Int, dim::Int) 
+    return dKij_dθp(k, X1, X2, i, j, p, dim)
+end
 
 include("stationary.jl")
 include("distance.jl")

--- a/src/kernels/lin.jl
+++ b/src/kernels/lin.jl
@@ -1,10 +1,10 @@
 # Linear covariance function
 
-@inline dotijp(X::AbstractMatrix, i::Int, j::Int, p::Int) = X[p,i]*X[p,j]
-@inline function dotij(X::AbstractMatrix, i::Int, j::Int, dim::Int)
-	s=zero(eltype(X))
+@inline dotijp(X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, p::Int) = X1[p,i]*X2[p,j]
+@inline function dotij(X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int)
+	s=zero(promote_type(eltype(X1), eltype(X2)))
 	@inbounds @simd for p in 1:dim
-		s+=dotijp(X,i,j,p)
+		s+=dotijp(X1,X2,i,j,p)
 	end
 	return s
 end

--- a/src/kernels/masked_kernel.jl
+++ b/src/kernels/masked_kernel.jl
@@ -32,7 +32,11 @@ struct MaskedData{M1<:AbstractMatrix,M2<:AbstractMatrix,KD<:KernelData} <: Kerne
 end
 function KernelData(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix)
     X1view = xview(masked,X1)
-    X2view = xview(masked,X2)
+    if X1 === X2
+        X2view = X1view
+    else
+        X2view = xview(masked,X2)
+    end
 	wrappeddata = KernelData(masked.kernel, X1view, X2view)
     return MaskedData(X1view, X2view, wrappeddata)
 end

--- a/src/kernels/masked_kernel.jl
+++ b/src/kernels/masked_kernel.jl
@@ -20,6 +20,7 @@ function Masked(kern::Kernel, active_dims::AbstractVector)
     K = typeof(kern)
     return Masked{K,dim}(kern, SVector{dim, Int}(active_dims))
 end
+xview(masked::Masked, X::AbstractMatrix) = view(X, masked.active_dims, :)
 
 ################
 ## KernelData ##
@@ -30,8 +31,8 @@ struct MaskedData{M1<:AbstractMatrix,M2<:AbstractMatrix,KD<:KernelData} <: Kerne
     wrappeddata::KD
 end
 function KernelData(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix)
-    X1view = view(X1,masked.active_dims,:)
-    X2view = view(X2,masked.active_dims,:)
+    X1view = xview(masked,X1)
+    X2view = xview(masked,X2)
 	wrappeddata = KernelData(masked.kernel, X1view, X2view)
     return MaskedData(X1view, X2view, wrappeddata)
 end
@@ -39,38 +40,26 @@ end
 @inline @inbounds function cov_ij(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData, i::Int, j::Int, dim::Int)
     return cov_ij(masked.kernel, data.X1view, data.X2view, data.wrappeddata, i, j, num_dims(masked))
 end
-@inline @inbounds function cov_ij(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int)
-    return cov_ij(masked.kernel, @view(X1[masked.active_dims, :]), @view(X2[masked.active_dims, :]), i, j, num_dims(masked))
-end
-@inline @inbounds function cov_ij(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int)
-    return cov_ij(masked, X1, X2, i, j, dim)
+@inline @inbounds function cov_ij(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int)
+    return cov_ij(masked.kernel, xview(masked,X1), xview(masked,X2), data, i, j, num_dims(masked))
 end
 
-@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, data::MaskedData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(masked.kernel, data.X1view, data.wrappeddata, i, j, p, num_dims(masked))
+@inline function dKij_dθp(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(masked.kernel, data.X1view, data.X2view, data.wrappeddata, i, j, p, num_dims(masked))
 end
-@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(masked.kernel, @view(X[masked.active_dims, :]), i, j, p, num_dims(masked))
+@inline function dKij_dθp(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(masked.kernel, xview(masked,X1), xview(masked,X2), data, i, j, p, num_dims(masked))
 end
-@inline function dKij_dθp(masked::Masked, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(masked, X, i, j, p, dim)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int, npars::Int)
+    X1view, X2view = xview(masked,X1), xview(masked,X2)
+    return dKij_dθ!(dK, masked.kernel, X1view, X2view, data, i, j, num_dims(masked), npars)
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, masked::Masked, X::AbstractMatrix, i::Int, j::Int, dim::Int, npars::Int)
-    Xview = view(X,masked.active_dims,:)
-    return dKij_dθ!(dK, masked.kernel, Xview, i, j, num_dims(masked), npars)
-end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, masked::Masked, X::AbstractMatrix, data::MaskedData, i::Int, j::Int, dim::Int, npars::Int)
-    return dKij_dθ!(dK, masked.kernel, data.X1view, data.wrappeddata, i, j, num_dims(masked), npars)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData, i::Int, j::Int, dim::Int, npars::Int)
+    return dKij_dθ!(dK, masked.kernel, data.X1view, data.X2view, data.wrappeddata, i, j, num_dims(masked), npars)
 end
 
-function cov(masked::Masked, x1::AbstractMatrix, x2::AbstractMatrix)
-    return cov(masked.kernel, view(x1,masked.active_dims,:), view(x2,masked.active_dims,:))
-end
-function cov(masked::Masked, x1::AbstractVector, x2::AbstractVector)
-    return cov(masked.kernel, view(x1,masked.active_dims), view(x2,masked.active_dims))
-end
 function kernel_data_key(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix)
-    k = kernel_data_key(masked.kernel, view(X1,masked.active_dims,:), view(X2,masked.active_dims,:))
+    k = kernel_data_key(masked.kernel, xview(masked,X1), xview(masked,X2))
     return @sprintf("%s_active=%s", k, masked.active_dims)
 end
 
@@ -79,25 +68,18 @@ get_param_names(masked::Masked) = get_param_names(masked.kernel)
 num_params(masked::Masked) = num_params(masked.kernel)
 set_params!(masked::Masked, hyp) = set_params!(masked.kernel, hyp)
 
-function cov(masked::Masked, X::AbstractMatrix, data::MaskedData)
-    return cov(masked.kernel, data.X1view, data.wrappeddata)
+function cov(masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData)
+    return cov(masked.kernel, data.X1view, data.X2view, data.wrappeddata)
 end
-function cov!(s::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::MaskedData)
-    return cov!(s, masked.kernel, data.X1view, data.wrappeddata)
+function cov!(s::AbstractMatrix, masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData)
+    return cov!(s, masked.kernel, data.X1view, data.X2view, data.wrappeddata)
 end
-function grad_slice!(dK::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::MaskedData, iparam::Int)
-    return grad_slice!(dK, masked.kernel, data.X1view, data.wrappeddata, iparam)
+function grad_slice!(dK::AbstractMatrix, masked::Masked, X1::AbstractMatrix, X2::AbstractMatrix, data::MaskedData, iparam::Int)
+    return grad_slice!(dK, masked.kernel, data.X1view, data.X2view, data.wrappeddata, iparam)
 end
 
-# with EmptyData
-function cov(masked::Masked, X::AbstractMatrix, data::EmptyData)
-    return cov(masked.kernel, view(X,masked.active_dims,:), data)
-end
-function cov!(s::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::EmptyData)
-    return cov!(s, masked.kernel, view(X,masked.active_dims,:), data)
-end
-function grad_slice!(dK::AbstractMatrix, masked::Masked, X::AbstractMatrix, data::EmptyData, iparam::Int)
-    return grad_slice!(dK, masked.kernel, view(X,masked.active_dims,:), data, iparam)
+function cov(masked::Masked, x1::AbstractVector, x2::AbstractVector)
+    return cov(masked.kernel, view(x1,masked.active_dims), view(x2,masked.active_dims))
 end
 
 # priors

--- a/src/kernels/mat.jl
+++ b/src/kernels/mat.jl
@@ -2,10 +2,10 @@
 abstract type MaternIso <: Isotropic{Euclidean} end
 abstract type MaternARD <: StationaryARD{WeightedEuclidean} end
 
-@inline function dKij_dθp(mat::MaternARD, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
-    r=distij(metric(mat),X,i,j,dim)
+@inline function dKij_dθp(mat::MaternARD, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+    r=distij(metric(mat),X1, X2,i,j,dim)
     if p <= dim
-        wdiffp=dist2ijk(metric(mat),X,i,j,p)
+        wdiffp=dist2ijk(metric(mat),X1, X2,i,j,p)
         if wdiffp > 0
             return dk_dll(mat,r,wdiffp)
         else
@@ -17,8 +17,8 @@ abstract type MaternARD <: StationaryARD{WeightedEuclidean} end
         return NaN
     end
 end
-@inline function dKij_dθp(mat::MaternARD, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(mat,X,i,j,p,dim)
+@inline function dKij_dθp(mat::MaternARD, X1::AbstractMatrix, X2::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(mat,X1,X2,i,j,p,dim)
 end
 
 @inline function dk_dθp(mat::MaternIso, r::Real, p::Int)

--- a/src/kernels/noise.jl
+++ b/src/kernels/noise.jl
@@ -34,9 +34,6 @@ cov(noise::Noise, x::AbstractVector, y::AbstractVector) = cov(noise, x ≈ y)
     return noise.σ2
     # return cov(noise, all(X1[z,i] ≈ X2[z,j] for z in 1:dim)) # this is inefficient for some reason
 end
-@inline @inbounds function cov_ij(noise::Noise, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int)
-    return cov_ij(noise, X1, X2, i, j, dim)
-end
 
 get_params(noise::Noise{T}) where T = T[log(noise.σ2) / 2]
 get_param_names(noise::Noise) = [:lσ]
@@ -47,10 +44,6 @@ function set_params!(noise::Noise, hyp::AbstractVector)
     noise.σ2 = exp(2 * hyp[1])
 end
 
-@inline dKij_dθp(noise::Noise, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int) =
+@inline dKij_dθp(noise::Noise, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int) =
     # 2 * cov(noise, view(X, :, i), view(X, :, j))
-    2 * cov_ij(noise, X, X, i, j, dim)
-
-@inline function dKij_dθp(noise::Noise, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(noise, X, i, j, p, dim)
-end
+    2 * cov_ij(noise, X1, X2, i, j, dim)

--- a/src/kernels/prod_kernel.jl
+++ b/src/kernels/prod_kernel.jl
@@ -51,6 +51,9 @@ end
         dK[ipar] *= cov_right
     end
 end
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
+    dKij_dθ!(dK, prodkern, X, i, j, dim, npars)
+end
 @inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix, data::PairData,
                                     i::Int, j::Int, dim::Int, npars::Int)
     cov_left  = cov_ij(prodkern.kleft,  X, X, data.data1, i, j, dim)

--- a/src/kernels/prod_kernel.jl
+++ b/src/kernels/prod_kernel.jl
@@ -11,60 +11,57 @@ function cov(sk::ProdKernel, x::AbstractVector, y::AbstractVector)
     cov(sk.kleft, x, y) * cov(sk.kright, x, y)
 end
 
-@inline cov_ij(k::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, i, j, dim) * cov_ij(k.kright, X1, X2, i, j, dim)
+@inline cov_ij(k::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, data, i, j, dim) * cov_ij(k.kright, X1, X2, data, i, j, dim)
 @inline cov_ij(k::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, data.data1, i, j, dim) * cov_ij(k.kright, X1, X2, data.data2, i, j, dim)
 
-@inline function dKij_dθp(prodkern::ProdKernel, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(prodkern::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(prodkern.kleft)
     if p<=np
-        cK_other = cov_ij(prodkern.kright, X, X, i, j, dim)
-        return dKij_dθp(prodkern.kleft, X, i,j,p,dim)*cK_other
+        cK_other = cov_ij(prodkern.kright, X1, X2, data, i, j, dim)
+        return dKij_dθp(prodkern.kleft,    X1, X2, data, i,j,p,dim)*cK_other
     else
-        cK_other = cov_ij(prodkern.kleft, X, X, i, j, dim)
-        return dKij_dθp(prodkern.kright, X, i,j,p-np,dim)*cK_other
+        cK_other = cov_ij(prodkern.kleft, X1, X2, data, i, j, dim)
+        return dKij_dθp(prodkern.kright,  X1, X2, data, i,j,p-np,dim)*cK_other
     end
 end
-@inline function dKij_dθp(prodkern::ProdKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(prodkern::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(prodkern.kleft)
     if p<=np
-        cK_other = cov_ij(prodkern.kright, X, X, data.data2, i, j, dim)
-        dKij_sub = dKij_dθp(prodkern.kleft, X,   data.data1, i, j, p, dim)
+        cK_other = cov_ij(prodkern.kright,  X1, X2, data.data2, i, j, dim)
+        dKij_sub = dKij_dθp(prodkern.kleft, X1, X2, data.data1, i, j, p, dim)
         return dKij_sub * cK_other
     else
-        cK_other = cov_ij(prodkern.kleft, X, X, data.data1, i, j, dim)
-        dKij_sub = dKij_dθp(prodkern.kright, X, data.data2, i, j, p-np, dim)
+        cK_other = cov_ij(prodkern.kleft,    X1, X2, data.data1, i, j, dim)
+        dKij_sub = dKij_dθp(prodkern.kright, X1, X2, data.data2, i, j, p-np, dim)
         return dKij_sub * cK_other
     end
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix,
-                                    i::Int, j::Int, dim::Int, npars::Int)
-    cov_left  = cov_ij(prodkern.kleft,  X, X, i, j, dim)
-    cov_right = cov_ij(prodkern.kright, X, X, i, j, dim)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix,
+                                    data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
+    cov_left  = cov_ij(prodkern.kleft,  X1, X2, data, i, j, dim)
+    cov_right = cov_ij(prodkern.kright, X1, X2, data, i, j, dim)
     npright = num_params(prodkern.kright)
     npleft = num_params(prodkern.kleft)
-    dKij_dθ!(dK, prodkern.kright, X, i, j, dim, npars-npleft)
+    dKij_dθ!(dK, prodkern.kright, X1, X2, data, i, j, dim, npars-npleft)
     for ipar in npright:-1:1
         dK[npleft+ipar] = dK[ipar]*cov_left
     end
-    dKij_dθ!(dK,  prodkern.kleft,  X, i, j, dim, npleft)
+    dKij_dθ!(dK,  prodkern.kleft,  X1, X2, data, i, j, dim, npleft)
     for ipar in 1:npleft
         dK[ipar] *= cov_right
     end
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
-    dKij_dθ!(dK, prodkern, X, i, j, dim, npars)
-end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X::AbstractMatrix, data::PairData,
-                                    i::Int, j::Int, dim::Int, npars::Int)
-    cov_left  = cov_ij(prodkern.kleft,  X, X, data.data1, i, j, dim)
-    cov_right = cov_ij(prodkern.kright, X, X, data.data2, i, j, dim)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, prodkern::ProdKernel, X1::AbstractMatrix, X2::AbstractMatrix,
+                                    data::PairData, i::Int, j::Int, dim::Int, npars::Int)
+    cov_left  = cov_ij(prodkern.kleft,  X1, X2, data.data1, i, j, dim)
+    cov_right = cov_ij(prodkern.kright, X1, X2, data.data2, i, j, dim)
     npright = num_params(prodkern.kright)
     npleft = num_params(prodkern.kleft)
-    dKij_dθ!(dK, prodkern.kright, X, data.data2, i, j, dim, npars-npleft)
+    dKij_dθ!(dK, prodkern.kright, X1, X2, data.data2, i, j, dim, npars-npleft)
     for ipar in npright:-1:1
         dK[npleft+ipar] = dK[ipar]*cov_left
     end
-    dKij_dθ!(dK,  prodkern.kleft,  X, data.data1, i, j, dim, npleft)
+    dKij_dθ!(dK,  prodkern.kleft,  X1, X2, data.data1, i, j, dim, npleft)
     for ipar in 1:npleft
         dK[ipar] *= cov_right
     end

--- a/src/kernels/rq_ard.jl
+++ b/src/kernels/rq_ard.jl
@@ -48,15 +48,16 @@ cov(rq::RQArd,r::Number) = rq.σ2*(1+0.5*r/rq.α)^(-rq.α)
     part = (1 + r / (2 * rq.α))
     return rq.σ2 * part^(-rq.α) * (r / (2 * part) - rq.α * log(part))
 end
-@inline function dKij_dθp(rq::RQArd, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(rq::RQArd, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
-        return dk_dll(rq, distij(metric(rq),X,i,j,dim), distijk(metric(rq),X,i,j,p))
+        return dk_dll(rq, distij(metric(rq),X1,X2,i,j,dim), distijk(metric(rq),X1,X2,i,j,p))
     elseif p==dim+1
-        return dk_dlσ(rq, distij(metric(rq),X,i,j,dim))
+        return dk_dlσ(rq, distij(metric(rq),X1,X2,i,j,dim))
     else
-        return dk_dlα(rq, distij(metric(rq),X,i,j,dim))
+        return dk_dlα(rq, distij(metric(rq),X1,X2,i,j,dim))
     end
 end
-@inline function dKij_dθp(rq::RQArd, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(rq,X,i,j,p,dim)
+@inline function dKij_dθp(rq::RQArd, X1::AbstractMatrix, X2::AbstractMatrix, data::StationaryARDData, 
+                          i::Int, j::Int, p::Int, dim::Int)
+    return dKij_dθp(rq,X1,X2,i,j,p,dim)
 end

--- a/src/kernels/se_ard.jl
+++ b/src/kernels/se_ard.jl
@@ -39,15 +39,12 @@ num_params(se::SEArd) = length(se.iℓ2) + 1
 cov(se::SEArd, r::Number) = se.σ2*exp(-r / 2)
 
 @inline dk_dll(se::SEArd, r::Real, wdiffp::Real) = wdiffp*cov(se,r)
-@inline function dKij_dθp(se::SEArd, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(se::SEArd, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
     if p <= dim
-        return dk_dll(se, distij(metric(se),X,i,j,dim), distijk(metric(se),X,i,j,p))
+        return dk_dll(se, distij(metric(se),X1,X2,i,j,dim), distijk(metric(se),X1,X2,i,j,p))
     elseif p==dim+1
-        return dk_dlσ(se, distij(metric(se),X,i,j,dim))
+        return dk_dlσ(se, distij(metric(se),X1,X2,i,j,dim))
     else
         return NaN
     end
-end
-@inline function dKij_dθp(se::SEArd, X::AbstractMatrix, data::StationaryARDData, i::Int, j::Int, p::Int, dim::Int)
-    return dKij_dθp(se,X,i,j,p,dim)
 end

--- a/src/kernels/stationary.jl
+++ b/src/kernels/stationary.jl
@@ -22,62 +22,8 @@ end
 @inline ard_weights(kernel::Stationary{WeightedEuclidean}) = kernel.iℓ2
 
 cov(k::Stationary, x::AbstractVector, y::AbstractVector) = cov(k, distance(k, x, y))
-@inline function cov_ij(k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int)
-    cov(k, distij(metric(k), X1, X2, i, j, dim))
-end
-@inline function cov_ij(k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int)
-    cov(k, distij(metric(k), X1, X2, i, j, dim))
-end
 @inline function cov_ij(k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix, data::KernelData, i::Int, j::Int, dim::Int)
     cov(k, distij(metric(k), X1, X2, i, j, dim))
-end
-function cov!(cK::AbstractMatrix, k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix)
-    dim1, nobsv1 = size(X1)
-    dim2, nobsv2 = size(X2)
-    dim1==dim2 || throw(ArgumentError("X1 and X2 must have same dimension"))
-    nobsv1==size(cK,1) || throw(ArgumentError("X1 and cK incompatible nobsv"))
-    nobsv2==size(cK,2) || throw(ArgumentError("X2 and cK incompatible nobsv"))
-    dim = dim1
-    met = metric(k)
-    for i in 1:nobsv1
-        for j in 1:nobsv2
-            cK[i,j] = cov(k, distij(met, X1, X2, i, j, dim))
-        end
-    end
-    return cK
-end
-function cov(k::Stationary, X1::AbstractMatrix, X2::AbstractMatrix)
-    nobsv1 = size(X1, 2)
-    nobsv2 = size(X2, 2)
-    cK = Array{eltype(X2)}(undef, nobsv1, nobsv2)
-    cov!(cK, k, X1, X2)
-    return cK
-end
-
-function cov!(cK::AbstractMatrix, k::Stationary, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    nobsv==size(cK,1) || throw(ArgumentError("X and cK incompatible nobsv"))
-    nobsv==size(cK,2) || throw(ArgumentError("X and cK incompatible nobsv"))
-    met = metric(k)
-    @inbounds for i in 1:nobsv
-        for j in 1:i
-            cK[i, j] = cK[j, i] = cov(k, distij(met, X, i, j, dim))
-        end
-    end
-    return cK
-end
-function cov!(cK::AbstractMatrix, k::Stationary, X::AbstractMatrix, data::StationaryData)
-    cov!(cK, k, X)
-end
-function cov(k::Stationary, X::AbstractMatrix, data::StationaryData)
-    nobsv = size(X, 2)
-    cK = Matrix{eltype(X)}(undef, nobsv, nobsv)
-    cov!(cK, k, X, data)
-end
-function cov(k::Stationary, X::AbstractMatrix)
-    nobsv = size(X, 2)
-    cK = Matrix{eltype(X)}(undef, nobsv, nobsv)
-    cov!(cK, k, X)
 end
 dk_dlσ(k::Stationary, r::Float64) = 2 * cov(k,r)
 
@@ -99,20 +45,20 @@ end
 @inline @inbounds function cov_ij(kern::Isotropic, X1::AbstractMatrix, X2::AbstractMatrix, data::IsotropicData, i::Int, j::Int, dim::Int)
     return cov(kern, data.R[i,j])
 end
-@inline function dKij_dθp(kern::Isotropic,X::AbstractMatrix,i::Int,j::Int,p::Int,dim::Int)
-    return dk_dθp(kern, distij(metric(kern),X,i,j,dim), p)
+@inline function dKij_dθp(kern::Isotropic,X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int,j::Int,p::Int,dim::Int)
+    return dk_dθp(kern, distij(metric(kern),X1, X2,i,j,dim), p)
 end
-@inline @inbounds function dKij_dθp(kern::Isotropic,X::AbstractMatrix,data::IsotropicData,i::Int,j::Int,p::Int,dim::Int)
+@inline @inbounds function dKij_dθp(kern::Isotropic,X1::AbstractMatrix, X2::AbstractMatrix,data::IsotropicData,i::Int,j::Int,p::Int,dim::Int)
     return dk_dθp(kern, data.R[i,j], p)
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Isotropic, X::AbstractMatrix, i::Int, j::Int, dim::Int, npars::Int)
-    r = distij(metric(kern),X,i,j,dim)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Isotropic, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
+    r = distij(metric(kern),X1, X2,i,j,dim)
     for p in 1:npars
         dK[p] = dk_dθp(kern, r, p)
     end
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Isotropic, X::AbstractMatrix, data::IsotropicData, 
-                                    i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, kern::Isotropic, X1::AbstractMatrix, X2::AbstractMatrix, 
+                                    data::IsotropicData, i::Int, j::Int, dim::Int, npars::Int)
     r = data.R[i,j]
     for iparam in 1:npars
         dK[iparam] = dk_dθp(kern, r, iparam)

--- a/src/kernels/sum_kernel.jl
+++ b/src/kernels/sum_kernel.jl
@@ -40,6 +40,9 @@ end
     end
     dKij_dθ!(dK,  sumkern.kleft,  X, i, j, dim, npleft)
 end
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
+    dKij_dθ!(dK, sumkern, X, i, j, dim, npars)
+end
 @inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int, npars::Int)
     npright = num_params(sumkern.kright)
     npleft = num_params(sumkern.kleft)

--- a/src/kernels/sum_kernel.jl
+++ b/src/kernels/sum_kernel.jl
@@ -12,61 +12,58 @@ function cov(sk::SumKernel, x::AbstractVector, y::AbstractVector)
 end
 
 
-@inline cov_ij(k::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, i, j, dim) + cov_ij(k.kright, X1, X2, i, j, dim)
+@inline cov_ij(k::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, data, i, j, dim) + cov_ij(k.kright, X1, X2, data, i, j, dim)
 @inline cov_ij(k::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int) = cov_ij(k.kleft, X1, X2, data.data1, i, j, dim) + cov_ij(k.kright, X1, X2, data.data2, i, j, dim)
 
-@inline function dKij_dθp(sumkern::SumKernel, X::AbstractMatrix, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(sumkern.kleft)
     if p<=np
-        return dKij_dθp(sumkern.kleft, X, i, j, p, dim)
+        return dKij_dθp(sumkern.kleft,  X1, X2, data, i, j, p, dim)
     else
-        return dKij_dθp(sumkern.kright, X, i, j, p-np, dim)
+        return dKij_dθp(sumkern.kright, X1, X2, data, i, j, p-np, dim)
     end
 end
-@inline function dKij_dθp(sumkern::SumKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
+@inline function dKij_dθp(sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, i::Int, j::Int, p::Int, dim::Int)
     np = num_params(sumkern.kleft)
     if p<=np
-        return dKij_dθp(sumkern.kleft, X, data.data1, i, j, p, dim)
+        return dKij_dθp(sumkern.kleft, X1, X2, data.data1, i, j, p, dim)
     else
-        return dKij_dθp(sumkern.kright, X, data.data2, i, j, p-np, dim)
+        return dKij_dθp(sumkern.kright, X1, X2, data.data2, i, j, p-np, dim)
     end
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
     npright = num_params(sumkern.kright)
     npleft = num_params(sumkern.kleft)
-    dKij_dθ!(dK, sumkern.kright, X, i, j, dim, npars-npleft)
+    dKij_dθ!(dK, sumkern.kright, X1, X2, data, i, j, dim, npars-npleft)
     for ipar in npright:-1:1
         dK[npleft+ipar] = dK[ipar]
     end
-    dKij_dθ!(dK,  sumkern.kleft,  X, i, j, dim, npleft)
+    dKij_dθ!(dK,  sumkern.kleft,  X1, X2, data, i, j, dim, npleft)
 end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, data::EmptyData, i::Int, j::Int, dim::Int, npars::Int)
-    dKij_dθ!(dK, sumkern, X, i, j, dim, npars)
-end
-@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int, npars::Int)
+@inline @inbounds function dKij_dθ!(dK::AbstractVector, sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, i::Int, j::Int, dim::Int, npars::Int)
     npright = num_params(sumkern.kright)
     npleft = num_params(sumkern.kleft)
-    dKij_dθ!(dK, sumkern.kright, X, data.data2, i, j, dim, npars-npleft)
+    dKij_dθ!(dK, sumkern.kright, X1, X2, data.data2, i, j, dim, npars-npleft)
     for ipar in npright:-1:1
         dK[npleft+ipar] = dK[ipar]
     end
-    dKij_dθ!(dK,  sumkern.kleft,  X, data.data1, i, j, dim, npleft)
+    dKij_dθ!(dK,  sumkern.kleft,  X1, X2, data.data1, i, j, dim, npleft)
 end
 
-function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X::AbstractMatrix, data::EmptyData, p::Int)
+function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::EmptyData, p::Int)
     np = num_params(sumkern.kleft)
     if p<=np
-        return grad_slice!(dK, sumkern.kleft, X, data, p)
+        return grad_slice!(dK, sumkern.kleft, X1, X2, data, p)
     else
-        return grad_slice!(dK, sumkern.kright, X, data, p-np)
+        return grad_slice!(dK, sumkern.kright, X1, X2, data, p-np)
     end
 end
-function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X::AbstractMatrix, data::PairData, p::Int)
+function grad_slice!(dK::AbstractMatrix, sumkern::SumKernel, X1::AbstractMatrix, X2::AbstractMatrix, data::PairData, p::Int)
     np = num_params(sumkern.kleft)
     if p<=np
-        return grad_slice!(dK, sumkern.kleft, X, data.data1, p)
+        return grad_slice!(dK, sumkern.kleft, X1, X2, data.data1, p)
     else
-        return grad_slice!(dK, sumkern.kright, X, data.data2, p-np)
+        return grad_slice!(dK, sumkern.kright, X1, X2, data.data2, p-np)
     end
 end
 

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -7,15 +7,14 @@ Gaussian process `gp`.
 function mcmc(gp::GPBase; nIter::Int=1000, burn::Int=1, thin::Int=1, ε::Float64=0.1,
               Lmin::Int=5, Lmax::Int=15, lik::Bool=true, noise::Bool=true,
               domean::Bool=true, kern::Bool=true)
-    Kgrad = Array{Float64}(undef, gp.nobs, gp.nobs)
-    L_bar = Array{Float64}(undef, gp.nobs, gp.nobs)
+    precomp = init_precompute(gp)
     params_kwargs = get_params_kwargs(gp; domean=domean, kern=kern, noise=noise, lik=lik)
     count = 0
     function calc_target(gp::GPBase, θ::AbstractVector) #log-target and its gradient
         count += 1
         try
             set_params!(gp, θ; params_kwargs...)
-            update_target_and_dtarget!(gp, Kgrad, L_bar; params_kwargs...)
+            update_target_and_dtarget!(gp, precomp; params_kwargs...)
             return true
         catch err
             if !all(isfinite.(θ))

--- a/src/sparse/determ_train_conditional.jl
+++ b/src/sparse/determ_train_conditional.jl
@@ -5,6 +5,10 @@ struct DeterminTrainCondStrat{M<:AbstractMatrix} <: CovarianceStrategy
     inducing::M
 end
 SubsetOfRegsStrategy(dtc::DeterminTrainCondStrat) = SubsetOfRegsStrategy(dtc.inducing)
+function init_precompute(covstrat::DeterminTrainCondStrat, X, y, k)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return init_precompute(SoR, X, y, k)
+end
 
 function alloc_cK(covstrat::DeterminTrainCondStrat, nobs)
     SoR = SubsetOfRegsStrategy(covstrat)
@@ -15,9 +19,13 @@ function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel,
     SoR = SubsetOfRegsStrategy(covstrat)
     return update_cK!(cK, x, kernel, logNoise, data, SoR)
 end
-function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::DeterminTrainCondStrat)
+function dmll_kern!(dmll::AbstractVector, gp::GPBase, precomp::SoRPrecompute, covstrat::DeterminTrainCondStrat)
     SoR = SubsetOfRegsStrategy(covstrat)
-    return dmll_kern!(dmll, k, X, cK, data, ααinvcKI, SoR)
+    return dmll_kern!(dmll, gp, precomp, SoR)
+end
+function dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::DeterminTrainCondStrat)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return dmll_noise(gp, precomp, SoR)
 end
 
 """

--- a/src/sparse/determ_train_conditional.jl
+++ b/src/sparse/determ_train_conditional.jl
@@ -39,11 +39,11 @@ end
     functions for the Subset of Regressors approximation.
 """
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
-                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    kernel::Kernel, meanf::Mean,
                     alpha::AbstractVector,
                     covstrat::DeterminTrainCondStrat, Ktrain::SubsetOfRegsPDMat)
     SoR = SubsetOfRegsStrategy(covstrat)
-    μ_SoR, Σ_SoR = predictMVN(xpred, xtrain, ytrain, kernel, meanf, logNoise, alpha, SoR, Ktrain)
+    μ_SoR, Σ_SoR = predictMVN(xpred, xtrain, ytrain, kernel, meanf, alpha, SoR, Ktrain)
     inducing = covstrat.inducing
     Kuu = Ktrain.Kuu
     

--- a/src/sparse/determ_train_conditional.jl
+++ b/src/sparse/determ_train_conditional.jl
@@ -1,0 +1,57 @@
+"""
+    Deterministic Training Conditional (DTC) covariance strategy.
+"""
+struct DeterminTrainCondStrat{M<:AbstractMatrix} <: CovarianceStrategy
+    inducing::M
+end
+SubsetOfRegsStrategy(dtc::DeterminTrainCondStrat) = SubsetOfRegsStrategy(dtc.inducing)
+
+function alloc_cK(covstrat::DeterminTrainCondStrat, nobs)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return alloc_cK(SoR, nobs)
+end
+function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel, 
+                    logNoise::Real, data::KernelData, covstrat::DeterminTrainCondStrat)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return update_cK!(cK, x, kernel, logNoise, data, SoR)
+end
+function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::DeterminTrainCondStrat)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return dmll_kern!(dmll, k, X, cK, data, ααinvcKI, SoR)
+end
+
+"""
+    Deterministic Training Conditional (DTC) multivariate normal predictions.
+
+    See Quiñonero-Candela and Rasmussen 2005, equations 20b.
+        μ_DTC = μ_SoR
+        Σ_DTC = Σxx - Qxx + Σ_SoR
+
+    where μ_DTC and Σ_DTC are the predictive mean and covariance
+    functions for the Subset of Regressors approximation.
+"""
+function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    alpha::AbstractVector,
+                    covstrat::DeterminTrainCondStrat, Ktrain::SubsetOfRegsPDMat)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    μ_SoR, Σ_SoR = predictMVN(xpred, xtrain, ytrain, kernel, meanf, logNoise, alpha, SoR, Ktrain)
+    inducing = covstrat.inducing
+    Kuu = Ktrain.Kuu
+    
+    Kux = cov(kernel, inducing, xpred) # Note: we've already computed this, but this way it looks cleaner
+    Qxx = PDMats.Xt_invA_X(Kuu, Kux)
+    Σxx = cov(kernel, xpred, xpred)
+    
+    Σ_DTC = Σxx - Qxx + Σ_SoR
+    LinearAlgebra.copytri!(Σ_DTC, 'U')
+    return μ_SoR, Σ_DTC
+end
+
+function DTC(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Real)
+    nobs = length(y)
+    covstrat = DeterminTrainCondStrat(inducing)
+    cK = alloc_cK(covstrat, nobs)
+    GPE(x, y, mean, kernel, logNoise, covstrat, EmptyData(), cK)
+end
+

--- a/src/sparse/determ_train_conditional.jl
+++ b/src/sparse/determ_train_conditional.jl
@@ -41,14 +41,13 @@ end
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
                     kernel::Kernel, meanf::Mean,
                     alpha::AbstractVector,
-                    covstrat::DeterminTrainCondStrat, Ktrain::SubsetOfRegsPDMat)
+                    covstrat::DeterminTrainCondStrat, Ktrain::AbstractPDMat)
     SoR = SubsetOfRegsStrategy(covstrat)
     μ_SoR, Σ_SoR = predictMVN(xpred, xtrain, ytrain, kernel, meanf, alpha, SoR, Ktrain)
     inducing = covstrat.inducing
     Kuu = Ktrain.Kuu
     
-    Kux = cov(kernel, inducing, xpred) # Note: we've already computed this, but this way it looks cleaner
-    Qxx = PDMats.Xt_invA_X(Kuu, Kux)
+    Qxx = getQaa(Ktrain, kernel, xpred)
     Σxx = cov(kernel, xpred, xpred)
     
     Σ_DTC = Σxx - Qxx + Σ_SoR

--- a/src/sparse/full_scale_approximation.jl
+++ b/src/sparse/full_scale_approximation.jl
@@ -1,0 +1,477 @@
+import Base: +
+import LinearAlgebra: tr
+const BlockIndices = Vector{<:AbstractVector{Int}}
+
+struct BlockDiagPDMat{T, V<:BlockIndices, PD<:AbstractPDMat{T}} <: AbstractPDMat{T}
+    blockindices::V
+    blockPD::Vector{PD}
+end
+function BlockDiagPDMat(blockindices::BlockIndices)
+    blockPD = [alloc_cK(length(ind)) for ind in blockindices]
+    return BlockDiagPDMat(blockindices, blockPD)
+end
+size(a::BlockDiagPDMat) = (sum(length,a.blockindices), sum(length,a.blockindices))
+size(a::BlockDiagPDMat, d::Int) = sum(length,a.blockindices)
+function \(a::BlockDiagPDMat, x::AbstractVector)
+    out = similar(x)
+    for (pd,ind) in zip(a.blockPD,a.blockindices)
+        out[ind] = pd \ x[ind]
+    end
+    return out
+end
+function \(a::BlockDiagPDMat, x::AbstractMatrix)
+    out = similar(x)
+    for (pd,ind) in zip(a.blockPD,a.blockindices)
+        out[ind,:] = pd \ x[ind,:]
+    end
+    return out
+end
+\(a::PDMat, x::UniformScaling) = a.chol \ Diagonal{Float64}(x, size(a,1))
+\(a::PDMat, x::Diagonal) = a.chol \ x
+function \(a::BlockDiagPDMat, x::Diagonal)
+    out = zeros(size(x)) # unfortunate! should maybe be block diagonal matrix.
+    for (pd,ind) in zip(a.blockPD,a.blockindices)
+        out[ind,ind] = pd \ Diagonal(x.diag[ind])
+    end
+    return out
+end
+logdet(a::BlockDiagPDMat) = sum(logdet, a.blockPD)
+tr(pd::AbstractPDMat) = tr(mat(pd))
+tr(a::BlockDiagPDMat) = sum(tr, a.blockPD)
+"""
+    trinv(pd::AbstractPDMat)
+
+Trace of the inverse of a positive definite matrix.
+"""
+function trinv(pd::AbstractPDMat)
+    return tr(pd \ I)
+    # Lk = inv(cholfactors(pd))
+    # return dot(Lk, Lk)
+end
+"""
+    trinv(a::BlockDiagPDMat)
+
+Trace of the inverse of a block diagonal positive definite matrix.
+
+This is obtained as the sum of the traces of the inverse of each block.
+"""
+trinv(a::BlockDiagPDMat) = sum(trinv, a.blockPD)
+function add!(a::AbstractMatrix, b::BlockDiagPDMat)
+    for (pd,ind) in zip(a.blockPD,a.blockindices)
+        block = @view(a[ind,ind])
+        block[:,:] += mat(pd)
+    end
+    return a
+end
++(a::AbstractMatrix, b::BlockDiagPDMat) = add!(copy(a), b)
+function Base.Matrix(a::BlockDiagPDMat)
+    K = zeros(size(a))
+    for (pd,ind) in zip(a.blockPD,a.blockindices)
+        copy!(@view(K[ind,ind]), mat(pd))
+    end
+    return K
+end
+mat(a::BlockDiagPDMat) = Matrix(a)
+
+"""
+    Positive Definite Matrix for Full Scale Approximation.
+"""
+mutable struct FullScalePDMat{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T},PD2<:BlockDiagPDMat} <: SparsePDMat{T}
+    inducing::M
+    ΣQR_PD::PD
+    Kuu::PD
+    Kuf::M2
+    Λ::PD2
+end
+size(a::FullScalePDMat) = (size(a.Kuf,2), size(a.Kuf,2))
+size(a::FullScalePDMat, d::Int) = size(a.Kuf,2)
+"""
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+    where Λ is a diagonal matrix (here given by σ²I + diag(Kff - Qff))
+    The Woodbury matrix identity gives
+        (A+UCV)⁻¹ = A⁻¹ - A⁻¹ U(C⁻¹ + V A⁻¹ U)⁻¹ V A⁻¹
+    which we use here with
+        A ← Λ
+        U = Kuf'
+        V = Kuf
+        C = Kuu⁻¹
+    which gives
+        Σ⁻¹ = Λ⁻¹ - Λ⁻¹ Kuf'(Kuu + Kuf Λ⁻¹ Kuf')⁻¹ Kuf Λ⁻¹
+            = Λ⁻¹ - Λ⁻¹ Kuf'(        ΣQR       )⁻¹ Kuf Λ⁻¹
+"""
+function \(a::FullScalePDMat, x)
+    Lk = whiten(a.ΣQR_PD, a.Kuf)
+    return a.Λ \ (x .- Lk' * (Lk * (a.Λ \ x)))
+end
+
+"""
+    trinvAB(A::FullScalePDMat, B::Diagonal)
+
+    Computes tr(A⁻¹ B) efficiently under the FSA approximation:
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+
+    Derivation:
+        tr(Σ⁻¹ B) = tr[ (Λ⁻¹ - Λ⁻² Kuf'(Kuu + Kuf Λ⁻¹ Kuf')⁻¹ Kuf) B ]
+                  = tr(Λ⁻¹ B) - tr( Λ⁻¹ Kuf' ΣQR⁻¹ Kuf Λ⁻¹ B )
+                  = tr(Λ⁻¹ B) - tr( Λ⁻¹ Kuf' ΣQR^(-1/2) ΣQR^(-1/2) Kuf Λ⁻¹ B )
+                                                        ╰────────────────╯
+                                                            ≡ L'
+                  = tr(Λ⁻¹ B) - tr(L*L'*B)
+                  = tr(Λ⁻¹ B) - dot(L, B*L)
+
+    See also: [`\`](@ref).
+"""
+function trinvAB(A::FullScalePDMat, B::Diagonal)
+    Λ = A.Λ
+    ΣPDinvKfu = convert(Matrix{Float64}, whiten(A.ΣQR_PD, A.Kuf)')
+    L = Λ \ ΣPDinvKfu # is there a better way?
+    return tr(Λ \ B) - dot(L, B * L)
+end
+
+"""
+    The matrix determinant lemma states that
+        logdet(A+UWV') = logdet(W⁻¹ + V'A⁻¹U) + logdet(W) + logdet(A)
+    So for
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+        logdet(Σ) = logdet(Kuu + Kuf Λ⁻¹ Kuf')       + logdet(Kuu⁻¹) + logdet(Λ)
+                  = logdet(        ΣQR             ) - logdet(Kuu)   + logdet(Λ)
+"""
+logdet(a::FullScalePDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + logdet(a.Λ)#sum(log.(a.Λ))
+function Base.Matrix(a::FullScalePDMat)
+    Lk = whiten(a.Kuu, a.Kuf)
+    Σ = Lk'Lk + mat(a.Λ)
+    nobs = size(Σ,1)
+    return Σ
+end
+
+function wrap_cK(cK::FullScalePDMat, inducing, ΣQR_PD, Kuu, Kuf, Λ::BlockDiagPDMat)
+    FullScalePDMat(inducing, ΣQR_PD, Kuu, Kuf, Λ)
+end
+"""
+    tr(a::FullScalePDMat)
+
+    Trace of the FSA approximation to the covariance matrix:
+
+    tr(Σ) = tr(Kuf' Kuu⁻¹ Kuf + Λ)
+          = tr(Kuf' Kuu⁻¹ Kuf) + tr(Λ)
+          = tr(Kuf' Kuu^{-1/2} Kuu^{-1/2} Kuf) + tr(Λ)
+                              ╰──────────────╯
+                                 ≡  Lk
+          = dot(Lk, Lk) + sum(diag(Λ))
+"""
+function LinearAlgebra.tr(a::FullScalePDMat)
+    Lk = whiten(a.Kuu, a.Kuf)
+    return tr(a.Λ) + dot(Lk, Lk)
+end
+
+
+"""
+    Fully Independent Training Conditional (FSA) covariance strategy.
+"""
+struct FullScaleApproxStrat{M<:AbstractMatrix, V<:BlockIndices} <: CovarianceStrategy
+    inducing::M
+    blockindices::V
+end
+SubsetOfRegsStrategy(fsa::FullScaleApproxStrat) = SubsetOfRegsStrategy(fsa.inducing)
+DeterminTrainCondStrat(fsa::FullScaleApproxStrat) = DeterminTrainCondStrat(fsa.inducing)
+
+function alloc_cK(covstrat::FullScaleApproxStrat, nobs)
+    # The objects that need to be allocated are very similar
+    # to SoR, so we'll use that as a starting point:
+    SoR = SubsetOfRegsStrategy(covstrat)
+    cK_SoR = alloc_cK(SoR, nobs)
+    # Additionally, we need to store the diagonal corrections.
+    Λ = BlockDiagPDMat(covstrat.blockindices)
+
+    cK_fsa = FullScalePDMat(
+        covstrat.inducing,
+        cK_SoR.ΣQR_PD,
+        cK_SoR.Kuu,
+        cK_SoR.Kuf,
+        Λ)
+    return cK_fsa
+end
+function update_cK!(cK::FullScalePDMat, X::AbstractMatrix, kernel::Kernel,
+                    logNoise::Real, data::KernelData, covstrat::FullScaleApproxStrat)
+    inducing = covstrat.inducing
+    blockindices = covstrat.blockindices
+
+    Kuu = cK.Kuu
+    Kuubuffer = mat(Kuu)
+    cov!(Kuubuffer, kernel, inducing)
+    Kuubuffer, chol = make_posdef!(Kuubuffer, cholfactors(cK.Kuu))
+    Kuu_PD = wrap_cK(cK.Kuu, Kuubuffer, chol)
+    Kuf = cov!(cK.Kuf, kernel, inducing, X)
+    Kfu = Kuf'
+
+    dim, nobs = size(X)
+    Λ = cK.Λ
+    @assert Λ.blockindices == blockindices
+    for (pd,ind) in zip(Λ.blockPD,Λ.blockindices)
+        Xblock = @view(X[:,ind])
+        Kblock = cov(kernel, Xblock)
+        Qchol = whiten(Kuu_PD, Kuf[:,ind])
+
+        blockbuffer = mat(pd)
+        # TODO: could use memory more efficiently
+        blockbuffer[:,:] = Kblock - Qchol'Qchol + exp(2*logNoise)*I
+        blockbuffer, chol = make_posdef!(blockbuffer, cholfactors(pd))
+    end
+
+    ΣQR = Kuf * (Λ \ Kfu) + Kuu
+    LinearAlgebra.copytri!(ΣQR, 'U')
+
+    ΣQR, chol = make_posdef!(ΣQR, cholfactors(cK.ΣQR_PD))
+    ΣQR_PD = wrap_cK(cK.ΣQR_PD, ΣQR, chol)
+    return wrap_cK(cK, inducing, ΣQR_PD, Kuu_PD, Kuf, Λ)
+end
+
+#==========================================
+  Log-likelihood gradients
+===========================================#
+function init_precompute(covstrat::FullScaleApproxStrat, X, y, kernel)
+    # here we can re-use the Subset of Regressors pre-computations
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return init_precompute(SoR, X, y, kernel)
+end
+
+"""
+dmll_kern!(dmll::AbstractVector, kernel::Kernel, X::AbstractMatrix, cK::AbstractPDMat, data::KernelData,
+                    alpha::AbstractVector, Kuu, Kuf, Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu,
+                    covstrat::FullScaleApproxStrat)
+Derivative of the log likelihood under the Fully Independent Training Conditional (fsa) approximation.
+
+Helpful reference: Vanhatalo, Jarno, and Aki Vehtari.
+                   "Sparse log Gaussian processes via MCMC for spatial epidemiology."
+                   In Gaussian processes in practice, pp. 73-89. 2007.
+
+Generally, for a multivariate normal with zero mean
+    ∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
+                    ╰───────────────╯     ╰──────────╯
+                           `V`                 `T`
+
+where Σ = Kff + σ²I.
+
+Notation: `f` is the observations, `u` is the inducing points.
+          ∂X stands for ∂X/∂θ, where θ is the kernel hyperparameters.
+
+In the case of the FSA approximation, we have
+    Σ = Λ + Qff
+    The second component gives
+    ∂(Qff) = ∂(Kfu Kuu⁻¹ Kuf)
+    which is used by the gradient function for the subset of regressors approximation,
+    and so I don't repeat it here.
+
+    for ∂Λ we have (with `i` indexing each block)
+    Λi = Ki - Qi + σ²I
+       = Ki - Kui' Kuu⁻¹ Kui + σ²
+    ∂Λi = ∂Ki - Kui' ∂(Kuu⁻¹) Kui - 2 ∂Kui' Kuu⁻¹ Kui
+        = ∂Ki + Kui' Kuu⁻¹ ∂(Kuu) Kuu⁻¹ Kui - 2 ∂Kui' Kuu⁻¹ Kui
+"""
+function dmll_kern!(dmll::AbstractVector, kernel::Kernel, X::AbstractMatrix, cK::AbstractPDMat, data::KernelData,
+                    alpha::AbstractVector, Kuu, Kuf, Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu,
+                    covstrat::FullScaleApproxStrat)
+    # first compute the SoR component
+    SoR = SubsetOfRegsStrategy(covstrat)
+    dmll_kern!(dmll, kernel, X, cK, data, alpha,
+               Kuu, Kuf, Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu,
+               SoR)
+    nparams = num_params(kernel)
+    dim, nobs = size(X)
+    inducing = covstrat.inducing
+    Λ = cK.Λ
+    for iparam in 1:nparams
+        # TODO: the grad_slice! calls here are redundant with the ones in the dmll_kern! call above
+        grad_slice!(∂Kuu, kernel, inducing, inducing, EmptyData(), iparam)
+        grad_slice!(∂Kfu, kernel, X,        inducing, EmptyData(), iparam)
+        V, T = 0.0, 0.0
+        # ∂Λdense = zeros(nobs, nobs)
+        for (pd,ind) in zip(Λ.blockPD,Λ.blockindices)
+            ∂Ki = similar(mat(pd))
+            Kui, ∂Kiu = Kuf[:,ind], ∂Kfu[ind,:]
+            grad_slice!(∂Ki, kernel, X[:,ind], X[:,ind], EmptyData(), iparam)
+            ∂Λi = ∂Ki 
+            ∂Λi = (∂Ki
+                  + Kuu⁻¹Kuf[:,ind]' * ∂Kuu * Kuu⁻¹Kuf[:,ind]
+                  - 2 * ∂Kiu * Kuu⁻¹Kuf[:,ind])
+            V += dot(alpha[ind], ∂Λi*alpha[ind])
+
+            # see trinvAB to understand next 3 lines
+            ΣPDinvKiu = convert(Matrix{Float64}, whiten(cK.ΣQR_PD, Kui)')
+            L = pd \ ΣPDinvKiu
+            T += tr(pd \ ∂Λi) - dot(L, ∂Λi*L)
+            # ∂Λdense[ind,ind] = ∂Λi
+        end
+        # # FOR DEBUG ONLY
+        # Talt = tr(cK \ ∂Λdense) # inefficient
+        # Valt = dot(alpha, ∂Λdense * alpha)
+        # @show T, Talt
+        # @show V, Valt
+        # # END DEBUG
+        dmll[iparam] += (V-T)/2
+    end
+    return dmll
+end
+function dmll_kern!(dmll::AbstractVector, gp::GPBase, precomp::SoRPrecompute, covstrat::FullScaleApproxStrat)
+    return dmll_kern!(dmll, gp.kernel, gp.x, gp.cK, gp.data, gp.alpha,
+                      gp.cK.Kuu, gp.cK.Kuf,
+                      precomp.Kuu⁻¹Kuf, precomp.Kuu⁻¹KufΣ⁻¹y, precomp.Σ⁻¹Kfu,
+                      precomp.∂Kuu, precomp.∂Kfu,
+                      covstrat)
+end
+
+"""
+    dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::FullScaleApproxStrat)
+
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
+
+∂Σ = I for derivative wrt σ², so
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ Σ⁻¹ y - 1/2 tr(Σ⁻¹)
+            = 1/2[ dot(α,α) - tr(Σ⁻¹) ]
+
+We have:
+    Σ⁻¹ = Λ⁻¹ - Λ⁻² Kuf'(        ΣQR       )⁻¹ Kuf
+Use the identity tr(A'A) = dot(A,A) to get:
+    tr(Σ⁻¹) = tr(Λ⁻¹) - dot(Lk, Lk) .
+where
+    Lk ≡ ΣQR^(-1/2) Kuf Λ⁻¹
+"""
+function dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::FullScaleApproxStrat)
+    cK = gp.cK
+    Λ = cK.Λ
+    Lk = Λ \ whiten(cK.ΣQR_PD, cK.Kuf)'
+    # # DEBUG
+    # noiseT = sum(1 ./ Λ) - dot(Lk, Lk)
+    # nobs = gp.nobs
+    # Talt = tr(cK \ Matrix(1.0*I, nobs, nobs))
+    # @show noiseT, Talt # should be same
+    # # END DEBUG
+    # @show tr(inv(Matrix(cK)))
+    # @show trinv(Λ) - dot(Lk, Lk)
+    return exp(2*gp.logNoise) * ( # Jacobian
+        dot(gp.alpha, gp.alpha)
+        - trinv(Λ) # sum(1 ./ Λ)
+        + dot(Lk, Lk)
+        )
+end
+
+
+function get_alpha_u(Ktrain::FullScalePDMat, xtrain::AbstractMatrix, ytrain::AbstractVector, meanf::Mean)
+    ΣQR_PD = Ktrain.ΣQR_PD
+    Kuf = Ktrain.Kuf
+    meantrain = mean(meanf, xtrain)
+    Λ = Ktrain.Λ
+    alpha_u = ΣQR_PD \ (Kuf * (Λ \ (ytrain-meantrain)) )
+    return alpha_u
+end
+
+"""
+predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector,
+                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    alpha::AbstractVector,
+                    covstrat::FullScaleApproxStrat, Ktrain::FullScalePDMat)
+    See Quiñonero-Candela and Rasmussen 2005, equations 24b.
+    Some derivations can be found below that are not spelled out in the paper.
+
+    Notation: Qab = Kau Kuu⁻¹ Kub
+              ΣQR = Kuu + σ⁻² Kuf Kuf'
+
+              x: prediction (test) locations
+              f: training (observed) locations
+              u: inducing point locations
+
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+    By Woodbury
+        Σ⁻¹ = Λ⁻¹ - Λ⁻² Kuf'(Kuu + Kuf Λ⁻¹ Kuf')⁻¹ Kuf
+            = Λ⁻¹ - Λ⁻² Kuf'(        ΣQR       )⁻¹ Kuf
+
+    The predictive mean can be derived (assuming zero mean function for simplicity)
+    μ = (Qxf+Λxf) (Qff + Λff)⁻¹ y
+      = Qxf (Qff + Λff)⁻¹ y   + Λxf (Qff + Λff)⁻¹ y
+        ╰─────────────────╯
+            same as FITC
+      = Kxu ΣQR⁻¹ Kuf Λff⁻¹ y + Λxf (Qff + Λff)⁻¹ y
+           ╰────────────────╯       ╰─────────────╯
+              ≡ alpha_u                ≡ alpha
+
+    Similarly for the posterior predictive covariance:
+    Σ = Σxx - (Qxf+Λxf) (Qff + Λff)⁻¹ (Qxf+Λxf)'
+      = Σxx - Kxu ΣQR⁻¹ Kuf Λ⁻¹ Qxf'                # substituting result from μ
+      = Σxx - Kxu ΣQR⁻¹  Kuf Λ⁻¹ Kfu Kuu⁻¹ Kux      # definition of Qxf
+      = Σxx - Kxu ΣQR⁻¹ (ΣQR - Kuu) Kuu⁻¹ Kux       # using definition of ΣQR
+      = Σxx - Kxu Kuu⁻¹ Kux + Kxu ΣQR⁻¹ Kux         # expanding
+      = Σxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
+"""
+function predictMVN(xpred::AbstractMatrix, blockindpred::BlockIndices, 
+                    xtrain::AbstractMatrix, ytrain::AbstractVector,
+                    kernel::Kernel, meanf::Mean,
+                    alpha::AbstractVector,
+                    covstrat::FullScaleApproxStrat, Ktrain::FullScalePDMat)
+    blockindtrain = covstrat.blockindices
+    ΣQR_PD = Ktrain.ΣQR_PD
+    inducing = covstrat.inducing
+
+    Kux = cov(kernel, inducing, xpred)
+
+    nx = size(xpred,2)
+    nf = size(xtrain,2)
+    # TODO: Λxf is fairly sparse: it should be possible to avoid its construction
+    Λxf = zeros(nx, nf)
+    for (predblock, trainblock) in zip(blockindpred, blockindtrain)
+        Xpredblock, Xtrainblock = xpred[:,predblock], xtrain[:,trainblock]
+        Kxf_block = cov(kernel, Xpredblock, Xtrainblock)
+        Qxf_block = getQab(Ktrain, kernel, Xpredblock, Xtrainblock)
+        Λxf[predblock,trainblock] = Kxf_block - Qxf_block
+    end
+
+    meanx = mean(meanf, xpred)
+    alpha_u = get_alpha_u(Ktrain, xtrain, ytrain, meanf)
+    mupred = meanx + (Kux' * alpha_u) + Λxf * alpha
+
+    Qxf = getQab(Ktrain, kernel, xpred, xtrain)
+    ΛplusQxf = Qxf + Λxf
+    Σxx = cov(kernel, xpred, xpred)
+    Σ_FSA = Σxx - ΛplusQxf * (Ktrain \ ΛplusQxf')
+    return mupred, Σ_FSA
+end
+
+"""
+    predict_f(gp::GPBase, X::Matrix{Float64}[; full_cov::Bool = false])
+
+Return posterior mean and variance of the Gaussian Process `gp` at specfic points which are
+given as columns of matrix `X`. If `full_cov` is `true`, the full covariance matrix is
+returned instead of only variances.
+"""
+function predict_f(gp::GPBase, x::AbstractMatrix, blockindpred::BlockIndices; full_cov::Bool=false)
+    size(x,1) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
+    if full_cov
+        return predict_full(gp, x, blockindpred)
+    else
+        ## Calculate prediction for each point independently
+        μ = Array{eltype(x)}(undef, size(x,2))
+        σ2 = similar(μ)
+        iblock = Vector{Int}(undef, size(x,2))
+        for (j,predblock) in enumerate(blockindpred)
+            iblock[predblock] = j
+        end
+        numblocks = length(blockindpred)
+        for k in 1:size(x,2)
+            subblockind = [j==iblock[k] ? [1] : [] for j in 1:numblocks]
+            m, sig = predict_full(gp, x[:,k:k], subblockind)
+            μ[k] = m[1]
+            σ2[k] = max(diag(sig)[1], 0.0)
+        end
+        return μ, σ2
+    end
+end
+predict_full(gp::GPE, xpred::AbstractMatrix, blockindpred::BlockIndices) = predictMVN(xpred, blockindpred, gp.x, gp.y, gp.kernel, gp.mean, gp.alpha, gp.covstrat, gp.cK)
+
+function FSA(x::AbstractMatrix, inducing::AbstractMatrix, blockindices::BlockIndices, 
+             y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Real)
+    nobs = length(y)
+    covstrat = FullScaleApproxStrat(inducing, blockindices)
+    cK = alloc_cK(covstrat, nobs)
+    GPE(x, y, mean, kernel, logNoise, covstrat, EmptyData(), cK)
+end

--- a/src/sparse/fully_indep_train_conditional.jl
+++ b/src/sparse/fully_indep_train_conditional.jl
@@ -1,0 +1,219 @@
+#========================================
+ Fully Independent Training Conditional
+=========================================#
+
+"""
+    Positive Definite Matrix for Fully Independent Training Conditional approximation.
+"""
+mutable struct FullyIndepPDMat{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T}} <: SparsePDMat{T}
+    inducing::M
+    ΣQR_PD::PD
+    Kuu::PD
+    Kuf::M2
+    Λ::Vector{Float64}
+end
+size(a::FullyIndepPDMat) = (size(a.Kuf,2), size(a.Kuf,2))
+size(a::FullyIndepPDMat, d::Int) = size(a.Kuf,2)
+"""
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+    where Λ is a diagonal matrix (here given by σ²I + diag(Kff - Qff))
+    The Woodbury matrix identity gives
+        (A+UCV)⁻¹ = A⁻¹ - A⁻¹ U(C⁻¹ + V A⁻¹ U)⁻¹ V A⁻¹
+    which we use here with
+        A ← Λ
+        U = Kuf'
+        V = Kuf
+        C = Kuu⁻¹
+    which gives
+        Σ⁻¹ = Λ⁻¹ - Λ⁻² Kuf'(Kuu + Kuf Λ⁻¹ Kuf')⁻¹ Kuf
+            = Λ⁻¹ - Λ⁻² Kuf'(        ΣQR       )⁻¹ Kuf
+"""
+function \(a::FullyIndepPDMat, x)
+    return x./a.Λ - (a.Kuf'*(a.ΣQR_PD \ (a.Kuf * x))) ./ a.Λ.^2
+end
+"""
+    The matrix determinant lemma states that
+        logdet(A+UWV') = logdet(W⁻¹ + V'A⁻¹U) + logdet(W) + logdet(A)
+    So for
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + (Λ+σ²I)
+        logdet(Σ) = logdet(Kuu + Kuf (Λ+σ²I)⁻¹ Kuf') + logdet(Kuu⁻¹) + logdet(Λ+σ²I)
+                  = logdet(        ΣQR             ) - logdet(Kuu)   + logdet(Λ+σ²I)
+"""
+logdet(a::FullyIndepPDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + sum(log.(a.Λ))
+
+function wrap_cK(cK::FullyIndepPDMat, inducing, ΣQR_PD, Kuu, Kuf, Λ::Vector)
+    FullyIndepPDMat(inducing, ΣQR_PD, Kuu, Kuf, Λ)
+end
+function LinearAlgebra.tr(a::FullyIndepPDMat)
+    Lk = whiten(a.Kuu, a.Kuf)
+    # log(sum(a.Λ)) + dot(a.Kuf, a.Kuu \ a.Kuf) # TODO: there may be a shortcut here
+    return log(sum(a.Λ)) + dot(Lk, Lk)
+end
+
+
+"""
+    Fully Independent Training Conditional (FITC) covariance strategy.
+"""
+struct FullyIndepStrat{M<:AbstractMatrix} <: CovarianceStrategy
+    inducing::M
+end
+SubsetOfRegsStrategy(fitc::FullyIndepStrat) = SubsetOfRegsStrategy(fitc.inducing)
+
+function alloc_cK(covstrat::FullyIndepStrat, nobs)
+    # The objects that need to be allocated are very similar
+    # to SoR, so we'll use that as a starting point:
+    SoR = SubsetOfRegsStrategy(covstrat)
+    cK_SoR = alloc_cK(SoR, nobs)
+    # Additionally, we need to store the diagonal corrections.
+    Λ = Vector{Float64}(undef, nobs)
+
+    cK_FITC = FullyIndepPDMat(
+        covstrat.inducing,
+        cK_SoR.ΣQR_PD,
+        cK_SoR.Kuu,
+        cK_SoR.Kuf,
+        Λ)
+    return cK_FITC
+end
+function update_cK!(cK::FullyIndepPDMat, X::AbstractMatrix, kernel::Kernel, 
+                    logNoise::Real, data::KernelData, covstrat::FullyIndepStrat)
+    inducing = covstrat.inducing
+    Kuu = cK.Kuu
+    Kuubuffer = mat(Kuu)
+    cov!(Kuubuffer, kernel, inducing)
+    Kuubuffer, chol = make_posdef!(Kuubuffer, cholfactors(cK.Kuu))
+    Kuu_PD = wrap_cK(cK.Kuu, Kuubuffer, chol)
+    Kuf = cov!(cK.Kuf, kernel, inducing, X)
+    Kfu = Kuf'
+
+    dim, nobs = size(X)
+    Kdiag = [cov_ij(kernel, X, X, data, i, i, dim) for i in 1:nobs]
+    Qdiag = [invquad(Kuu_PD, Kuf[:,i]) for i in 1:nobs]
+    Λ = exp(2*logNoise) .+ Kdiag.-Qdiag
+    
+    ΣQR = (Kuf ./ Λ') * Kfu + Kuu
+    LinearAlgebra.copytri!(ΣQR, 'U')
+    
+    ΣQR, chol = make_posdef!(ΣQR, cholfactors(cK.ΣQR_PD))
+    ΣQR_PD = wrap_cK(cK.ΣQR_PD, ΣQR, chol)
+    return wrap_cK(cK, inducing, ΣQR_PD, Kuu_PD, Kuf, Λ)
+end
+
+#==========================================
+  Log-likelihood gradients
+===========================================#
+function init_precompute(covstrat::FullyIndepStrat, X, y, k)
+    # here we can re-use the Subset of Regressors pre-computations
+    SoR = SubsetOfRegsStrategy(covstrat)
+    return init_precompute(SoR, X, y, k)
+end
+    
+function dmll_kern!(dmll::AbstractVector, gp::GPBase, precomp::SoRPrecompute, covstrat::FullyIndepStrat)
+    SoR = SubsetOfRegsStrategy(covstrat)
+    cK = gp.cK
+    return dmll_kern!(dmll, gp.kernel, gp.x, cK, gp.data, gp.alpha, 
+                      cK.Kuu, cK.Kuf,
+                      precomp.Kuu⁻¹Kuf, precomp.Kuu⁻¹KufΣ⁻¹y, precomp.Σ⁻¹Kfu,
+                      precomp.∂Kuu, precomp.∂Kfu,
+                      SoR)
+end
+
+"""
+    dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::FullyIndepStrat)
+
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
+
+∂Σ = I for derivative wrt σ², so
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ Σ⁻¹ y - 1/2 tr(Σ⁻¹)
+            = 1/2[ dot(α,α) - tr(Σ⁻¹) ]
+
+We have:
+    Σ⁻¹ = Λ⁻¹ - Λ⁻² Kuf'(        ΣQR       )⁻¹ Kuf
+Use the identity tr(A'A) = dot(A,A) to get:
+    Lk ≡ ΣQR^(-1/2) Kuf Λ⁻¹
+which gives
+    tr(Σ⁻¹) = tr(Λ⁻¹) - dot(Lk, Lk) .
+"""
+function dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::FullyIndepStrat)
+    nobs = gp.nobs
+    cK = gp.cK
+    Λ = cK.Λ
+    Lk = whiten(cK.ΣQR_PD, cK.Kuf ./ Λ')
+    return exp(2*gp.logNoise) * ( # Jacobian
+        dot(gp.alpha, gp.alpha) 
+        - sum(1 ./ Λ)
+        + dot(Lk, Lk)
+        )
+end
+
+"""
+predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    alpha::AbstractVector,
+                    covstrat::FullyIndepStrat, Ktrain::FullyIndepPDMat)
+    See Quiñonero-Candela and Rasmussen 2005, equations 24b.
+    Some derivations can be found below that are not spelled out in the paper.
+
+    Notation: Qab = Kau Kuu⁻¹ Kub
+              ΣQR = Kuu + σ⁻² Kuf Kuf'
+
+              x: prediction (test) locations
+              f: training (observed) locations
+              u: inducing point locations
+
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + Λ
+    By Woodbury
+        Σ⁻¹ = Λ⁻¹ - Λ⁻² Kuf'(Kuu + Kuf Λ⁻¹ Kuf')⁻¹ Kuf
+            = Λ⁻¹ - Λ⁻² Kuf'(        ΣQR       )⁻¹ Kuf
+
+    The predictive mean can be derived (assuming zero mean function for simplicity)
+    μ = Qxf (Qff + Λ)⁻¹ y
+      = Kxu Kuu⁻¹ Kuf [Λ⁻¹ - Λ⁻² Kuf' ΣQR⁻¹ Kuf] y   # see Woodbury formula above.
+      = Kxu Kuu⁻¹ [ΣQR - Kuf Λ⁻¹ Kfu] ΣQR⁻¹ Kuf Λ⁻¹ y # factoring out common terms
+      = Kxu Kuu⁻¹ [Kuu] ΣQR⁻¹ Kuf Λ⁻¹ y               # using definition of ΣQR
+      = Kxu ΣQR⁻¹ Kuf Λ⁻¹ y                           # matches equation 16b
+    
+    Similarly for the posterior predictive covariance:
+    Σ = Σxx - Qxf (Qff + Λ)⁻¹ Qxf'
+      = Σxx - Kxu ΣQR⁻¹ Kuf Λ⁻¹ Qxf'                # substituting result from μ
+      = Σxx - Kxu ΣQR⁻¹  Kuf Λ⁻¹ Kfu Kuu⁻¹ Kux      # definition of Qxf
+      = Σxx - Kxu ΣQR⁻¹ (ΣQR - Kuu) Kuu⁻¹ Kux       # using definition of ΣQR
+      = Σxx - Kxu Kuu⁻¹ Kux + Kxu ΣQR⁻¹ Kux         # expanding
+      = Σxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
+"""
+function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    alpha::AbstractVector,
+                    covstrat::FullyIndepStrat, Ktrain::FullyIndepPDMat)
+    ΣQR_PD = Ktrain.ΣQR_PD
+    inducing = covstrat.inducing
+    Kuf = Ktrain.Kuf
+    Kuu = Ktrain.Kuu
+    
+    Kux = cov(kernel, inducing, xpred)
+    
+    meanx = mean(meanf, xpred)
+    meanf = mean(meanf, xtrain)
+    alpha_u = ΣQR_PD \ (Kuf * ((ytrain-meanf) ./ Ktrain.Λ) )
+    mupred = meanx + (Kux' * alpha_u)
+    
+    Lck = PDMats.whiten(ΣQR_PD, Kux)
+    Σ_SoR = Lck'Lck # Kux' * (ΣQR_PD \ Kux)
+    LinearAlgebra.copytri!(Σ_SoR, 'U')
+
+    Qxx = PDMats.Xt_invA_X(Kuu, Kux)
+    Σxx = cov(kernel, xpred, xpred)
+
+    Σ_FITC = Σxx - Qxx + Σ_SoR
+    return mupred, Σ_FITC
+end
+
+
+function FITC(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Real)
+    nobs = length(y)
+    covstrat = FullyIndepStrat(inducing)
+    cK = alloc_cK(covstrat, nobs)
+    GPE(x, y, mean, kernel, logNoise, covstrat, EmptyData(), cK)
+end

--- a/src/sparse/fully_indep_train_conditional.jl
+++ b/src/sparse/fully_indep_train_conditional.jl
@@ -41,6 +41,15 @@ end
                   = logdet(        ΣQR             ) - logdet(Kuu)   + logdet(Λ+σ²I)
 """
 logdet(a::FullyIndepPDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + sum(log.(a.Λ))
+function Base.Matrix(a::FullyIndepPDMat)
+    Lk = whiten(a.Kuu, a.Kuf)
+    Σ = Lk'Lk
+    nobs = size(Σ,1)
+    for i in 1:nobs
+        Σ[i,i] += a.Λ[i]
+    end
+    return Σ
+end
 
 function wrap_cK(cK::FullyIndepPDMat, inducing, ΣQR_PD, Kuu, Kuf, Λ::Vector)
     FullyIndepPDMat(inducing, ΣQR_PD, Kuu, Kuf, Λ)

--- a/src/sparse/fully_indep_train_conditional.jl
+++ b/src/sparse/fully_indep_train_conditional.jl
@@ -259,7 +259,7 @@ predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector
       = Σxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
 """
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector,
-                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    kernel::Kernel, meanf::Mean,
                     alpha::AbstractVector,
                     covstrat::FullyIndepStrat, Ktrain::FullyIndepPDMat)
     ΣQR_PD = Ktrain.ΣQR_PD

--- a/src/sparse/fully_indep_train_conditional.jl
+++ b/src/sparse/fully_indep_train_conditional.jl
@@ -54,6 +54,18 @@ end
 function wrap_cK(cK::FullyIndepPDMat, inducing, ΣQR_PD, Kuu, Kuf, Λ::Vector)
     FullyIndepPDMat(inducing, ΣQR_PD, Kuu, Kuf, Λ)
 end
+"""
+    tr(a::FullyIndepPDMat)
+
+    Trace of the FITC approximation to the covariance matrix:
+
+    tr(Σ) = tr(Kuf' Kuu⁻¹ Kuf + Λ)
+          = tr(Kuf' Kuu⁻¹ Kuf) + tr(Λ)
+          = tr(Kuf' Kuu^{-1/2) Kuu^{-1/2} Kuf) + tr(Λ)
+                              ╰──────────────╯
+                                 ≡  Lk
+          = dot(Lk, Lk) + sum(diag(Λ))
+"""
 function LinearAlgebra.tr(a::FullyIndepPDMat)
     Lk = whiten(a.Kuu, a.Kuf)
     return sum(a.Λ) + dot(Lk, Lk)

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -12,4 +12,4 @@ function get_ααinvcKI!(ααinvcKI::AbstractMatrix, cK::SparsePDMat, α::Vector
 end
 
 include("subsetofregressors.jl")
-
+include("determ_train_conditional.jl")

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -13,3 +13,4 @@ end
 
 include("subsetofregressors.jl")
 include("determ_train_conditional.jl")
+include("fully_indep_train_conditional.jl")

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -1,0 +1,3 @@
+abstract type SparsePDMat{T} <: AbstractPDMat{T} end
+
+include("subsetofregressors.jl")

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -1,3 +1,5 @@
 abstract type SparsePDMat{T} <: AbstractPDMat{T} end
+abstract type SparseStrategy <: CovarianceStrategy end
 
 include("subsetofregressors.jl")
+

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -1,5 +1,19 @@
 abstract type SparsePDMat{T} <: AbstractPDMat{T} end
 abstract type SparseStrategy <: CovarianceStrategy end
 
+function get_ααinvcKI!(ααinvcKI::AbstractMatrix, cK::SparsePDMat, α::Vector)
+    nobs = length(α)
+    size(ααinvcKI) == (nobs, nobs) || throw(ArgumentError(
+                @sprintf("Buffer for ααinvcKI should be a %dx%d matrix, not %dx%d",
+                         nobs, nobs,
+                         size(ααinvcKI,1), size(ααinvcKI,2))))
+    # fill!(ααinvcKI, 0)
+    # @inbounds for i in 1:nobs
+        # ααinvcKI[i,i] = -1.0
+    # end
+    ααinvcKI = cK \ (-I)
+    BLAS.ger!(1.0, α, α, ααinvcKI)
+end
+
 include("subsetofregressors.jl")
 

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -1,3 +1,5 @@
+import LinearAlgebra: tr, logdet
+
 abstract type SparsePDMat{T} <: AbstractPDMat{T} end
 abstract type SparseStrategy <: CovarianceStrategy end
 
@@ -14,3 +16,4 @@ end
 include("subsetofregressors.jl")
 include("determ_train_conditional.jl")
 include("fully_indep_train_conditional.jl")
+include("full_scale_approximation.jl")

--- a/src/sparse/sparseGP.jl
+++ b/src/sparse/sparseGP.jl
@@ -7,11 +7,7 @@ function get_ααinvcKI!(ααinvcKI::AbstractMatrix, cK::SparsePDMat, α::Vector
                 @sprintf("Buffer for ααinvcKI should be a %dx%d matrix, not %dx%d",
                          nobs, nobs,
                          size(ααinvcKI,1), size(ααinvcKI,2))))
-    # fill!(ααinvcKI, 0)
-    # @inbounds for i in 1:nobs
-        # ααinvcKI[i,i] = -1.0
-    # end
-    ααinvcKI = cK \ (-I)
+    ααinvcKI[:,:] = cK \ (-I)
     BLAS.ger!(1.0, α, α, ααinvcKI)
 end
 

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -258,12 +258,13 @@ end
       = Kxu ΣQR⁻¹ Kux                               # simplifying
 """
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
-                    kernel::Kernel, meanf::Mean, logNoise::Real,
+                    kernel::Kernel, meanf::Mean,
                     alpha::AbstractVector,
                     covstrat::SubsetOfRegsStrategy, Ktrain::SubsetOfRegsPDMat)
     ΣQR_PD = Ktrain.ΣQR_PD
     inducing = covstrat.inducing
     Kuf = Ktrain.Kuf
+    logNoise = Ktrain.logNoise
     
     Kux = cov(kernel, inducing, xpred)
     

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -1,0 +1,102 @@
+"""
+    Subset of Regressors sparse positive definite matrix.
+"""
+mutable struct SubsetOfRegressors{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T}} <: SparsePDMat{T}
+    inducing::M
+    ΣQR_PD::PD
+    Kuu::M2
+    Kuf::M2
+    logNoise::Float64
+end
+size(a::SubsetOfRegressors) = (size(a.Kuf,2), size(a.Kuf,2))
+size(a::SubsetOfRegressors, d::Int) = size(a.Kuf,2)
+"""
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + σ²I
+    By Woodbury
+        Σ⁻¹ = σ⁻²I - σ⁻⁴ Kuf'(Kuu + σ⁻² Kuf Kuf')⁻¹ Kuf
+            = σ⁻²I - σ⁻⁴ Kuf'(       ΣQR        )⁻¹ Kuf
+"""
+function \(a::SubsetOfRegressors, x::AbstractArray)
+    return exp(-2*a.logNoise)*x - exp(-4*a.logNoise)*a.Kuf'*(a.ΣQR_PD \ (a.Kuf * x))
+end
+logdet(a::SubsetOfRegressors) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + 2*a.logNoise*size(a,1)
+
+function wrap_cK(cK::SubsetOfRegressors, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
+    SubsetOfRegressors(inducing, ΣQR_PD, Kuu, Kuf, logNoise)
+end
+function update_cK!(gp::GPE{X,Y,M,K,P,D}) where {X<:AbstractMatrix,Y<:AbstractVector,M<:Mean,K<:Kernel,P<:SubsetOfRegressors,D<:EmptyData}
+    old_cK = gp.cK
+    Kuu = cov!(old_cK.Kuu, gp.kernel, old_cK.inducing)
+    Kuf = cov!(old_cK.Kuf, gp.kernel, old_cK.inducing, gp.x)
+    Kfu = Kuf'
+    
+    ΣQR = exp(-2*gp.logNoise) * Kuf * Kfu + Kuu
+    LinearAlgebra.copytri!(ΣQR, 'U')
+    
+    ΣQR, chol = make_posdef!(ΣQR, cholfactors(old_cK.ΣQR_PD))
+    ΣQR_PD = wrap_cK(old_cK.ΣQR_PD, ΣQR, chol)
+    gp.cK = wrap_cK(gp.cK, old_cK.inducing, ΣQR_PD, Kuu, Kuf, gp.logNoise)
+end
+function alloc_SoR(nobs, inducing)
+    ninducing = size(inducing, 2)
+    Kuu  = Matrix{Float64}(undef, ninducing, ninducing)
+    Kuf  = Matrix{Float64}(undef, ninducing, nobs)
+    ΣQR  = Matrix{Float64}(undef, ninducing, ninducing)
+    chol = Matrix{Float64}(undef, ninducing, ninducing)
+    cK = SubsetOfRegressors(inducing, 
+                            PDMats.PDMat(ΣQR, Cholesky(chol, 'U', 0)), # ΣQR_PD
+                            Kuu, Kuf, 42.0)
+    return cK
+end
+function SoR(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64)
+    nobs = length(y)
+    cK = alloc_SoR(nobs, inducing)
+    GPE(x, y, mean, kernel, logNoise, EmptyData(), cK)
+end
+
+"""
+    See Quiñonero-Candela and Rasmussen 2005, equations 16b.
+    Some derivations can be found below that are not spelled out in the paper.
+
+    Notation: Qab = Kau Kuu⁻¹ Kub
+              ΣQR = Kuu + σ⁻² Kuf Kuf'
+
+              x: test location
+              f: training locations
+              u: inducing point locations
+
+    The predictive mean can be derived (assuming zero mean function for simplicity)
+    μ = Qxf (Qff + σ²I)⁻¹ y
+      = Kxu Kuu⁻¹ Kuf [σ⁻²I - σ⁻⁴ Kuf' ΣQR⁻¹ Kuf] y   # see Woodbury formula above.
+      = σ⁻² Kxu Kuu⁻¹ [ΣQR - σ⁻² Kuf Kfu] ΣQR⁻¹ Kuf y # factoring out common terms
+      = σ⁻² Kxu Kuu⁻¹ [Kuu] ΣQR⁻¹ Kuf y               # using definition of ΣQR
+      = σ⁻² Kxu ΣQR⁻¹ Kuf y                           # matches equation 16b
+    
+    Similarly for the posterior predictive covariance:
+    Σ = Qxx - Qxf (Qff + σ²I)⁻¹ Qxf'
+      = Qxx - σ⁻² Kxu ΣQR⁻¹ Kuf Qxf'                # substituting result from μ
+      = Qxx - σ⁻² Kxu ΣQR⁻¹  Kuf Kfu    Kuu⁻¹ Kux   # definition of Qxf
+      = Qxx -     Kxu ΣQR⁻¹ (ΣQR - Kuu) Kuu⁻¹ Kux   # using definition of ΣQR
+      = Qxx - Kxu Kuu⁻¹ Kux + Kxu ΣQR⁻¹ Kux         # expanding
+      = Qxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
+      = Kxu ΣQR⁻¹ Kux                               # simplifying
+"""
+function _predict(gp::GPE{X,Y,M,K,P,D}, x::AbstractMatrix)  where {X<:AbstractMatrix,Y<:AbstractVector,M<:Mean,K<:Kernel,P<:SubsetOfRegressors,D<:EmptyData}
+    ΣQR_PD = gp.cK.ΣQR_PD
+    inducing = gp.cK.inducing
+    Kuf = gp.cK.Kuf
+    
+    Kxu = cov(gp.kernel, x, inducing)
+    Kux = Matrix(Kxu') # annoying memory allocation
+    
+    meanx = mean(gp.mean, x)
+    meanf = mean(gp.mean, gp.x)
+    alpha_u = ΣQR_PD \ (Kuf * (gp.y-meanf))
+    mu = meanx + exp(-2*gp.logNoise) * Kxu * alpha_u
+    
+    Sigma_raw = Kxu * (ΣQR_PD \ Kux)
+    LinearAlgebra.copytri!(Sigma_raw, 'U')
+    m, chol = make_posdef!(Sigma_raw)
+    return mu, PDMat(m, chol)
+end

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -25,6 +25,9 @@ function \(a::SubsetOfRegsPDMat, x)
 end
 logdet(a::SubsetOfRegsPDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + 2*a.logNoise*size(a,1)
 
+function wrap_cK(cK::SubsetOfRegsPDMat, inducing, ΣQR_PD, Kuu, Kuf, logNoise::Scalar)
+    wrap_cK(cK, inducing, ΣQR_PD, Kuu, Kuf, logNoise.value)
+end
 function wrap_cK(cK::SubsetOfRegsPDMat, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
     SubsetOfRegsPDMat(inducing, ΣQR_PD, Kuu, Kuf, logNoise)
 end
@@ -124,7 +127,7 @@ end
       = Kxu ΣQR⁻¹ Kux                               # simplifying
 """
 function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
-                    kernel::Kernel, meanf::Mean, logNoise::Float64,
+                    kernel::Kernel, meanf::Mean, logNoise::Real,
                     alpha::AbstractVector,
                     covstrat::SubsetOfRegsStrategy, Ktrain::SubsetOfRegsPDMat)
     ΣQR_PD = Ktrain.ΣQR_PD
@@ -145,7 +148,7 @@ function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::Abstr
 end
 
 
-function SoR(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64)
+function SoR(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Real)
     nobs = length(y)
     covstrat = SubsetOfRegsStrategy(inducing)
     cK = alloc_cK(covstrat, nobs)

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -61,12 +61,12 @@ function alloc_cK(covstrat::SubsetOfRegsStrategy, nobs)
     Kuf  = Matrix{Float64}(undef, ninducing, nobs)
     ΣQR  = Matrix{Float64}(undef, ninducing, ninducing)
     chol = Matrix{Float64}(undef, ninducing, ninducing)
-    cK = SubsetOfRegsPDMat(inducing, 
+    cK = SubsetOfRegsPDMat(inducing,
                             PDMats.PDMat(ΣQR, Cholesky(chol, 'U', 0)), # ΣQR_PD
                             Kuu_PD, Kuf, 42.0)
     return cK
 end
-function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel, 
+function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel,
                     logNoise::Real, data::KernelData, covstrat::SubsetOfRegsStrategy)
     inducing = covstrat.inducing
     Kuu = cK.Kuu
@@ -76,10 +76,10 @@ function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel,
     Kuu_PD = wrap_cK(cK.Kuu, Kuubuffer, chol)
     Kuf = cov!(cK.Kuf, kernel, inducing, x)
     Kfu = Kuf'
-    
+
     ΣQR = exp(-2*logNoise) * Kuf * Kfu + Kuu
     LinearAlgebra.copytri!(ΣQR, 'U')
-    
+
     ΣQR, chol = make_posdef!(ΣQR, cholfactors(cK.ΣQR_PD))
     ΣQR_PD = wrap_cK(cK.ΣQR_PD, ΣQR, chol)
     return wrap_cK(cK, inducing, ΣQR_PD, Kuu_PD, Kuf, logNoise)
@@ -104,25 +104,25 @@ function SoRPrecompute(nobs::Int, ninducing::Int)
     return SoRPrecompute(Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu)
 end
 
-function init_precompute(covstrat::SubsetOfRegsStrategy, X, y, k)
+function init_precompute(covstrat::SubsetOfRegsStrategy, X, y, kernel)
     nobs = size(X, 2)
     ninducing = size(covstrat.inducing, 2)
     SoRPrecompute(nobs, ninducing)
 end
-    
-function precompute!(precomp::SoRPrecompute, gp::GPBase) 
+
+function precompute!(precomp::SoRPrecompute, gp::GPBase)
     cK = gp.cK
     alpha = gp.alpha
     Kuf = cK.Kuf
     Kuu = cK.Kuu
 
-    precomp.Kuu⁻¹Kuf[:,:] = Kuu \ Kuf # Kuu⁻¹Kuf 
+    precomp.Kuu⁻¹Kuf[:,:] = Kuu \ Kuf # Kuu⁻¹Kuf
     precomp.Kuu⁻¹KufΣ⁻¹y[:] = vec(Kuu \ (Kuf * alpha)) # Kuu⁻¹Kuf Σ⁻1 y appears repeatedly, so pre-compute
     precomp.Σ⁻¹Kfu[:,:] = cK \ (Kuf') # TODO: reduce memory allocations
     return precomp
 end
 function dmll_kern!(dmll::AbstractVector, gp::GPBase, precomp::SoRPrecompute, covstrat::SubsetOfRegsStrategy)
-    return dmll_kern!(dmll, gp.kernel, gp.x, gp.cK, gp.data, gp.alpha, 
+    return dmll_kern!(dmll, gp.kernel, gp.x, gp.cK, gp.data, gp.alpha,
                       gp.cK.Kuu, gp.cK.Kuf,
                       precomp.Kuu⁻¹Kuf, precomp.Kuu⁻¹KufΣ⁻¹y, precomp.Σ⁻¹Kfu,
                       precomp.∂Kuu, precomp.∂Kfu,
@@ -145,26 +145,26 @@ function dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::SubsetOfRegsStrat
     cK = gp.cK
     Lk = whiten(cK.ΣQR_PD, cK.Kuf)
     return exp(2*gp.logNoise) * (
-        dot(gp.alpha, gp.alpha) 
+        dot(gp.alpha, gp.alpha)
         - exp(-2*gp.logNoise) * nobs
         + exp(-4*gp.logNoise)  * dot(Lk, Lk)
         )
 end
 
 """
-    dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::SubsetOfRegsStrategy)
+    dmll_kern!(dmll::AbstractVector, kernel::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::SubsetOfRegsStrategy)
 
 Derivative of the log likelihood under the Subset of Regressors (SoR) approximation.
 
-Helpful reference: Vanhatalo, Jarno, and Aki Vehtari. 
-                   "Sparse log Gaussian processes via MCMC for spatial epidemiology." 
+Helpful reference: Vanhatalo, Jarno, and Aki Vehtari.
+                   "Sparse log Gaussian processes via MCMC for spatial epidemiology."
                    In Gaussian processes in practice, pp. 73-89. 2007.
 
 Generally, for a multivariate normal with zero mean
     ∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
                     ╰───────────────╯     ╰──────────╯
                            `V`                 `T`
-                       
+
 where Σ = Kff + σ²I.
 
 Notation: `f` is the observations, `u` is the inducing points.
@@ -177,23 +177,28 @@ In the SoR approximation, we replace Kff with Qff = Kfu Kuu⁻¹ Kuf
 
 ∂(Kuu⁻¹) = -Kuu⁻¹ ∂(Kuu) Kuu⁻¹  --------^
 
-Also have pre-computed α = Σ⁻¹ y, so `V` can now be computed 
+Also have pre-computed α = Σ⁻¹ y, so `V` can now be computed
 efficiency (O(nm²) I think…) by careful ordering of the matrix multiplication steps.
 
+For `T`, we use the identity tr(AB) = dot(A',B):
+tr(Σ⁻¹ ∂Σ) = 2 tr(Σ⁻¹ ∂(Kfu) Kuu⁻¹ Kuf) + tr(Σ⁻¹ Kfu ∂(Kuu⁻¹) Kuf)
+           = 2 dot((Σ⁻¹ ∂(Kfu))', Kuu⁻¹ Kuf) - tr(Σ⁻¹ Kfu Kuu⁻¹ ∂Kuu Kuu⁻¹ Kuf)
+           = 2 dot((Σ⁻¹ ∂(Kfu))', Kuu⁻¹ Kuf) - dot((Σ⁻¹ Kfu)', Kuu⁻¹ ∂Kuu Kuu⁻¹ Kuf)
+which again is computed in O(nm²).
 """
-function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::AbstractPDMat, data::KernelData, 
+function dmll_kern!(dmll::AbstractVector, kernel::Kernel, X::AbstractMatrix, cK::AbstractPDMat, data::KernelData,
                     alpha::AbstractVector, Kuu, Kuf, Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu,
                     covstrat::SubsetOfRegsStrategy)
     dim, nobs = size(X)
     inducing = covstrat.inducing
     ninducing = size(inducing, 2)
-    nparams = num_params(k)
+    nparams = num_params(kernel)
     @assert nparams == length(dmll)
     dK_buffer = Vector{Float64}(undef, nparams)
     dmll[:] .= 0.0
     for iparam in 1:nparams
-        grad_slice!(∂Kuu, k, inducing, inducing, EmptyData(), iparam)
-        grad_slice!(∂Kfu, k, X, inducing,        EmptyData(), iparam)
+        grad_slice!(∂Kuu, kernel, inducing, inducing, EmptyData(), iparam)
+        grad_slice!(∂Kfu, kernel, X, inducing,        EmptyData(), iparam)
         V =  2 * dot(alpha, ∂Kfu * (Kuu⁻¹KufΣ⁻¹y))    # = 2 y' Σ⁻¹ ∂Kfu Kuu⁻¹ Kuf Σ⁻¹y
         V -= dot(Kuu⁻¹KufΣ⁻¹y, ∂Kuu * (Kuu⁻¹KufΣ⁻¹y)) # = y' Σ⁻¹ Kfu ∂(Kuu⁻¹) Kuf Σ⁻¹ y
 
@@ -202,21 +207,14 @@ function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::Abst
 
         # # BELOW FOR DEBUG ONLY
         # ∂Σ = ∂Kfu * Kuu⁻¹Kuf
-        # @inbounds for i in 1:nobs
-            # ∂Σ[i,i] *= 2
-            # for j in 1:(i-1)
-                # s = ∂Σ[i,j] + ∂Σ[j,i]
-                # ∂Σ[i,j] = s
-                # ∂Σ[j,i] = s
-            # end
-        # end
+        # ∂Σ += ∂Σ'
         # ∂Σ -= Kuu⁻¹Kuf' * ∂Kuu * Kuu⁻¹Kuf
         # Valt = alpha'*∂Σ*alpha
         # Talt = tr(cK \ ∂Σ)
         # @show V, Valt
         # @show T, Talt
-        # dmll_alt = dot(ααinvcKI, ∂Σ)/2
-        # @show dmll_alt, dmll[iparam]
+        # # dmll_alt = dot(ααinvcKI, ∂Σ)/2
+        # # @show dmll_alt, dmll[iparam]
         # # ABOVE FOR DEBUG ONLY
 
         dmll[iparam] = (V-T)/2
@@ -247,7 +245,7 @@ end
       = σ⁻² Kxu Kuu⁻¹ [ΣQR - σ⁻² Kuf Kfu] ΣQR⁻¹ Kuf y # factoring out common terms
       = σ⁻² Kxu Kuu⁻¹ [Kuu] ΣQR⁻¹ Kuf y               # using definition of ΣQR
       = σ⁻² Kxu ΣQR⁻¹ Kuf y                           # matches equation 16b
-    
+
     Similarly for the posterior predictive covariance:
     Σ = Qxx - Qxf (Qff + σ²I)⁻¹ Qxf'
       = Qxx - σ⁻² Kxu ΣQR⁻¹ Kuf Qxf'                # substituting result from μ
@@ -257,7 +255,7 @@ end
       = Qxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
       = Kxu ΣQR⁻¹ Kux                               # simplifying
 """
-function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector,
                     kernel::Kernel, meanf::Mean,
                     alpha::AbstractVector,
                     covstrat::SubsetOfRegsStrategy, Ktrain::SubsetOfRegsPDMat)
@@ -265,14 +263,14 @@ function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::Abstr
     inducing = covstrat.inducing
     Kuf = Ktrain.Kuf
     logNoise = Ktrain.logNoise
-    
+
     Kux = cov(kernel, inducing, xpred)
-    
+
     meanx = mean(meanf, xpred)
     meanf = mean(meanf, xtrain)
     alpha_u = ΣQR_PD \ (Kuf * (ytrain-meanf))
     mupred = meanx + exp(-2*logNoise) * (Kux' * alpha_u)
-    
+
     Lck = PDMats.whiten(ΣQR_PD, Kux)
     Σpred = Lck'Lck # Kux' * (ΣQR_PD \ Kux)
     LinearAlgebra.copytri!(Σpred, 'U')

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -34,6 +34,15 @@ end
 function LinearAlgebra.tr(a::SubsetOfRegsPDMat)
     exp(2*a.logNoise)*size(a.Kuf,2) + dot(a.Kuf, a.Kuu \ a.Kuf) # TODO: there may be a shortcut here
 end
+function Base.Matrix(a::SubsetOfRegsPDMat)
+    Lk = whiten(a.Kuu, a.Kuf)
+    Σ = Lk'Lk
+    nobs = size(Σ,1)
+    for i in 1:nobs
+        Σ[i,i] += exp(2*a.logNoise)
+    end
+    return Σ
+end
 
 #========================================
  Subset of Regressors strategy

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -1,15 +1,18 @@
+#==========================================================
+ Sparse Positive Definite Matrix for Subset of Regressors
+===========================================================#
 """
     Subset of Regressors sparse positive definite matrix.
 """
-mutable struct SubsetOfRegressors{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T}} <: SparsePDMat{T}
+mutable struct SubsetOfRegsPDMat{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T}} <: SparsePDMat{T}
     inducing::M
     ΣQR_PD::PD
     Kuu::M2
     Kuf::M2
     logNoise::Float64
 end
-size(a::SubsetOfRegressors) = (size(a.Kuf,2), size(a.Kuf,2))
-size(a::SubsetOfRegressors, d::Int) = size(a.Kuf,2)
+size(a::SubsetOfRegsPDMat) = (size(a.Kuf,2), size(a.Kuf,2))
+size(a::SubsetOfRegsPDMat, d::Int) = size(a.Kuf,2)
 """
     We have
         Σ ≈ Kuf' Kuu⁻¹ Kuf + σ²I
@@ -17,42 +20,35 @@ size(a::SubsetOfRegressors, d::Int) = size(a.Kuf,2)
         Σ⁻¹ = σ⁻²I - σ⁻⁴ Kuf'(Kuu + σ⁻² Kuf Kuf')⁻¹ Kuf
             = σ⁻²I - σ⁻⁴ Kuf'(       ΣQR        )⁻¹ Kuf
 """
-function \(a::SubsetOfRegressors, x::AbstractArray)
+function \(a::SubsetOfRegsPDMat, x::AbstractArray)
     return exp(-2*a.logNoise)*x - exp(-4*a.logNoise)*a.Kuf'*(a.ΣQR_PD \ (a.Kuf * x))
 end
-logdet(a::SubsetOfRegressors) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + 2*a.logNoise*size(a,1)
+logdet(a::SubsetOfRegsPDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + 2*a.logNoise*size(a,1)
 
-function wrap_cK(cK::SubsetOfRegressors, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
-    SubsetOfRegressors(inducing, ΣQR_PD, Kuu, Kuf, logNoise)
+function wrap_cK(cK::SubsetOfRegsPDMat, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
+    SubsetOfRegsPDMat(inducing, ΣQR_PD, Kuu, Kuf, logNoise)
 end
-function update_cK!(gp::GPE{X,Y,M,K,P,D}) where {X<:AbstractMatrix,Y<:AbstractVector,M<:Mean,K<:Kernel,P<:SubsetOfRegressors,D<:EmptyData}
-    old_cK = gp.cK
-    Kuu = cov!(old_cK.Kuu, gp.kernel, old_cK.inducing)
-    Kuf = cov!(old_cK.Kuf, gp.kernel, old_cK.inducing, gp.x)
+
+#========================================
+ Subset of Regressors strategy
+=========================================#
+
+struct SubsetOfRegsStrategy{M<:AbstractMatrix} <: CovarianceStrategy
+    inducing::M
+end
+
+function update_cK!(covstrat::SubsetOfRegsStrategy, cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel, logNoise::Real, data::KernelData)
+    inducing = covstrat.inducing
+    Kuu = cov!(cK.Kuu, kernel, inducing)
+    Kuf = cov!(cK.Kuf, kernel, inducing, x)
     Kfu = Kuf'
     
-    ΣQR = exp(-2*gp.logNoise) * Kuf * Kfu + Kuu
+    ΣQR = exp(-2*logNoise) * Kuf * Kfu + Kuu
     LinearAlgebra.copytri!(ΣQR, 'U')
     
-    ΣQR, chol = make_posdef!(ΣQR, cholfactors(old_cK.ΣQR_PD))
-    ΣQR_PD = wrap_cK(old_cK.ΣQR_PD, ΣQR, chol)
-    gp.cK = wrap_cK(gp.cK, old_cK.inducing, ΣQR_PD, Kuu, Kuf, gp.logNoise)
-end
-function alloc_SoR(nobs, inducing)
-    ninducing = size(inducing, 2)
-    Kuu  = Matrix{Float64}(undef, ninducing, ninducing)
-    Kuf  = Matrix{Float64}(undef, ninducing, nobs)
-    ΣQR  = Matrix{Float64}(undef, ninducing, ninducing)
-    chol = Matrix{Float64}(undef, ninducing, ninducing)
-    cK = SubsetOfRegressors(inducing, 
-                            PDMats.PDMat(ΣQR, Cholesky(chol, 'U', 0)), # ΣQR_PD
-                            Kuu, Kuf, 42.0)
-    return cK
-end
-function SoR(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64)
-    nobs = length(y)
-    cK = alloc_SoR(nobs, inducing)
-    GPE(x, y, mean, kernel, logNoise, EmptyData(), cK)
+    ΣQR, chol = make_posdef!(ΣQR, cholfactors(cK.ΣQR_PD))
+    ΣQR_PD = wrap_cK(cK.ΣQR_PD, ΣQR, chol)
+    return wrap_cK(cK, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
 end
 
 """
@@ -62,8 +58,8 @@ end
     Notation: Qab = Kau Kuu⁻¹ Kub
               ΣQR = Kuu + σ⁻² Kuf Kuf'
 
-              x: test location
-              f: training locations
+              x: prediction (test) locations
+              f: training (observed) locations
               u: inducing point locations
 
     The predictive mean can be derived (assuming zero mean function for simplicity)
@@ -82,21 +78,46 @@ end
       = Qxx - Qxx           + Kxu ΣQR⁻¹ Kux         # definition of Qxx
       = Kxu ΣQR⁻¹ Kux                               # simplifying
 """
-function _predict(gp::GPE{X,Y,M,K,P,D}, x::AbstractMatrix)  where {X<:AbstractMatrix,Y<:AbstractVector,M<:Mean,K<:Kernel,P<:SubsetOfRegressors,D<:EmptyData}
-    ΣQR_PD = gp.cK.ΣQR_PD
-    inducing = gp.cK.inducing
-    Kuf = gp.cK.Kuf
+function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::AbstractVector, 
+                    kernel::Kernel, meanf::Mean, logNoise::Float64,
+                    alpha::AbstractVector,
+                    covstrat::SubsetOfRegsStrategy, Ktrain::SubsetOfRegsPDMat)
+    ΣQR_PD = Ktrain.ΣQR_PD
+    inducing = covstrat.inducing
+    Kuf = Ktrain.Kuf
     
-    Kxu = cov(gp.kernel, x, inducing)
+    Kxu = cov(kernel, xpred, inducing)
     Kux = Matrix(Kxu') # annoying memory allocation
     
-    meanx = mean(gp.mean, x)
-    meanf = mean(gp.mean, gp.x)
-    alpha_u = ΣQR_PD \ (Kuf * (gp.y-meanf))
-    mu = meanx + exp(-2*gp.logNoise) * Kxu * alpha_u
+    meanx = mean(meanf, xpred)
+    meanf = mean(meanf, xtrain)
+    alpha_u = ΣQR_PD \ (Kuf * (ytrain-meanf))
+    mupred = meanx + exp(-2*logNoise) * Kxu * alpha_u
     
-    Sigma_raw = Kxu * (ΣQR_PD \ Kux)
-    LinearAlgebra.copytri!(Sigma_raw, 'U')
-    m, chol = make_posdef!(Sigma_raw)
-    return mu, PDMat(m, chol)
+    Σpred = Kxu * (ΣQR_PD \ Kux)
+    LinearAlgebra.copytri!(Σpred, 'U')
+    return mupred, Σpred
+    # m, chol = make_posdef!(Sigma_raw)
+    # return mu, PDMat(m, chol)
+end
+
+
+function SoR(x::AbstractMatrix, inducing::AbstractMatrix, y::AbstractVector, mean::Mean, kernel::Kernel, logNoise::Float64)
+    nobs = length(y)
+    covstrat = SubsetOfRegsStrategy(inducing)
+    cK = alloc_cK(covstrat, nobs)
+    GPE(x, y, mean, kernel, logNoise, covstrat, EmptyData(), cK)
+end
+
+function alloc_cK(covstrat::SubsetOfRegsStrategy, nobs)
+    inducing = covstrat.inducing
+    ninducing = size(inducing, 2)
+    Kuu  = Matrix{Float64}(undef, ninducing, ninducing)
+    Kuf  = Matrix{Float64}(undef, ninducing, nobs)
+    ΣQR  = Matrix{Float64}(undef, ninducing, ninducing)
+    chol = Matrix{Float64}(undef, ninducing, ninducing)
+    cK = SubsetOfRegsPDMat(inducing, 
+                            PDMats.PDMat(ΣQR, Cholesky(chol, 'U', 0)), # ΣQR_PD
+                            Kuu, Kuf, 42.0)
+    return cK
 end

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -146,15 +146,15 @@ function predictMVN(xpred::AbstractMatrix, xtrain::AbstractMatrix, ytrain::Abstr
     inducing = covstrat.inducing
     Kuf = Ktrain.Kuf
     
-    Kxu = cov(kernel, xpred, inducing)
-    Kux = Matrix(Kxu') # annoying memory allocation
+    Kux = cov(kernel, inducing, xpred)
     
     meanx = mean(meanf, xpred)
     meanf = mean(meanf, xtrain)
     alpha_u = ΣQR_PD \ (Kuf * (ytrain-meanf))
-    mupred = meanx + exp(-2*logNoise) * Kxu * alpha_u
+    mupred = meanx + exp(-2*logNoise) * (Kux' * alpha_u)
     
-    Σpred = Kxu * (ΣQR_PD \ Kux)
+    Lck = PDMats.whiten(ΣQR_PD, Kux)
+    Σpred = Lck'Lck # Kux' * (ΣQR_PD \ Kux)
     LinearAlgebra.copytri!(Σpred, 'U')
     return mupred, Σpred
 end

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -7,7 +7,7 @@
 mutable struct SubsetOfRegsPDMat{T,M<:AbstractMatrix,PD<:AbstractPDMat{T},M2<:AbstractMatrix{T}} <: SparsePDMat{T}
     inducing::M
     ΣQR_PD::PD
-    Kuu::M2
+    Kuu::PD
     Kuf::M2
     logNoise::Float64
 end
@@ -20,7 +20,7 @@ size(a::SubsetOfRegsPDMat, d::Int) = size(a.Kuf,2)
         Σ⁻¹ = σ⁻²I - σ⁻⁴ Kuf'(Kuu + σ⁻² Kuf Kuf')⁻¹ Kuf
             = σ⁻²I - σ⁻⁴ Kuf'(       ΣQR        )⁻¹ Kuf
 """
-function \(a::SubsetOfRegsPDMat, x::AbstractArray)
+function \(a::SubsetOfRegsPDMat, x)
     return exp(-2*a.logNoise)*x - exp(-4*a.logNoise)*a.Kuf'*(a.ΣQR_PD \ (a.Kuf * x))
 end
 logdet(a::SubsetOfRegsPDMat) = logdet(a.ΣQR_PD) - logdet(a.Kuu) + 2*a.logNoise*size(a,1)
@@ -41,17 +41,24 @@ function alloc_cK(covstrat::SubsetOfRegsStrategy, nobs)
     inducing = covstrat.inducing
     ninducing = size(inducing, 2)
     Kuu  = Matrix{Float64}(undef, ninducing, ninducing)
+    chol_uu = Matrix{Float64}(undef, ninducing, ninducing)
+    Kuu_PD = PDMats.PDMat(Kuu, Cholesky(chol_uu, 'U', 0))
     Kuf  = Matrix{Float64}(undef, ninducing, nobs)
     ΣQR  = Matrix{Float64}(undef, ninducing, ninducing)
     chol = Matrix{Float64}(undef, ninducing, ninducing)
     cK = SubsetOfRegsPDMat(inducing, 
                             PDMats.PDMat(ΣQR, Cholesky(chol, 'U', 0)), # ΣQR_PD
-                            Kuu, Kuf, 42.0)
+                            Kuu_PD, Kuf, 42.0)
     return cK
 end
-function update_cK!(covstrat::SubsetOfRegsStrategy, cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel, logNoise::Real, data::KernelData)
+function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel, 
+                    logNoise::Real, data::KernelData, covstrat::SubsetOfRegsStrategy)
     inducing = covstrat.inducing
-    Kuu = cov!(cK.Kuu, kernel, inducing)
+    Kuu = cK.Kuu
+    Kuubuffer = mat(Kuu)
+    cov!(Kuubuffer, kernel, inducing)
+    Kuubuffer, chol = make_posdef!(Kuubuffer, cholfactors(cK.Kuu))
+    Kuu_PD = wrap_cK(cK.Kuu, Kuubuffer, chol)
     Kuf = cov!(cK.Kuf, kernel, inducing, x)
     Kfu = Kuf'
     
@@ -60,7 +67,27 @@ function update_cK!(covstrat::SubsetOfRegsStrategy, cK::SubsetOfRegsPDMat, x::Ab
     
     ΣQR, chol = make_posdef!(ΣQR, cholfactors(cK.ΣQR_PD))
     ΣQR_PD = wrap_cK(cK.ΣQR_PD, ΣQR, chol)
-    return wrap_cK(cK, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
+    return wrap_cK(cK, inducing, ΣQR_PD, Kuu_PD, Kuf, logNoise)
+end
+
+
+function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::SubsetOfRegsStrategy)
+    dim, nobs = size(X)
+    inducing = covstrat.inducing
+    ninducing = size(inducing, 2)
+    nparams = num_params(k)
+    @assert nparams == length(dmll)
+    dK_buffer = Vector{Float64}(undef, nparams)
+    dmll[:] .= 0.0
+    Kuf = cK.Kuf
+    Kuu = cK.Kuu
+    ∂Kuu = similar(mat(Kuu))
+    ∂Kfu = Matrix{Float64}(undef, nobs, ninducing)
+    for iparam in 1:nparams
+        grad_slice!(∂Kuu, k, inducing, inducing, EmptyData(), iparam)
+        grad_slice!(∂Kfu, k, X, inducing,        EmptyData(), iparam)
+    end
+    return dmll
 end
 
 """
@@ -73,6 +100,12 @@ end
               x: prediction (test) locations
               f: training (observed) locations
               u: inducing point locations
+
+    We have
+        Σ ≈ Kuf' Kuu⁻¹ Kuf + σ²I
+    By Woodbury
+        Σ⁻¹ = σ⁻²I - σ⁻⁴ Kuf'(Kuu + σ⁻² Kuf Kuf')⁻¹ Kuf
+            = σ⁻²I - σ⁻⁴ Kuf'(       ΣQR        )⁻¹ Kuf
 
     The predictive mean can be derived (assuming zero mean function for simplicity)
     μ = Qxf (Qff + σ²I)⁻¹ y

--- a/src/sparse/subsetofregressors.jl
+++ b/src/sparse/subsetofregressors.jl
@@ -31,6 +31,9 @@ end
 function wrap_cK(cK::SubsetOfRegsPDMat, inducing, ΣQR_PD, Kuu, Kuf, logNoise)
     SubsetOfRegsPDMat(inducing, ΣQR_PD, Kuu, Kuf, logNoise)
 end
+function LinearAlgebra.tr(a::SubsetOfRegsPDMat)
+    exp(2*a.logNoise)*size(a.Kuf,2) + dot(a.Kuf, a.Kuu \ a.Kuf) # TODO: there may be a shortcut here
+end
 
 #========================================
  Subset of Regressors strategy
@@ -73,34 +76,142 @@ function update_cK!(cK::SubsetOfRegsPDMat, x::AbstractMatrix, kernel::Kernel,
     return wrap_cK(cK, inducing, ΣQR_PD, Kuu_PD, Kuf, logNoise)
 end
 
+#==========================================
+  Log-likelihood gradients
+===========================================#
+struct SoRPrecompute <: AbstractGradientPrecompute
+    Kuu⁻¹Kuf::Matrix{Float64}
+    Kuu⁻¹KufΣ⁻¹y::Vector{Float64}
+    Σ⁻¹Kfu::Matrix{Float64}
+    ∂Kuu::Matrix{Float64} # buffer
+    ∂Kfu::Matrix{Float64} # buffer
+end
+function SoRPrecompute(nobs::Int, ninducing::Int)
+    Kuu⁻¹Kuf = Matrix{Float64}(undef, ninducing, nobs)
+    Kuu⁻¹KufΣ⁻¹y =  Vector{Float64}(undef, ninducing)
+    Σ⁻¹Kfu = Matrix{Float64}(undef, nobs, ninducing)
+    ∂Kuu = Matrix{Float64}(undef, ninducing, ninducing)
+    ∂Kfu = Matrix{Float64}(undef, nobs, ninducing)
+    return SoRPrecompute(Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu)
+end
 
-function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::SubsetOfRegsStrategy)
+function init_precompute(covstrat::SubsetOfRegsStrategy, X, y, k)
+    nobs = size(X, 2)
+    ninducing = size(covstrat.inducing, 2)
+    SoRPrecompute(nobs, ninducing)
+end
+    
+function precompute!(precomp::SoRPrecompute, gp::GPBase) 
+    cK = gp.cK
+    alpha = gp.alpha
+    Kuf = cK.Kuf
+    Kuu = cK.Kuu
+
+    precomp.Kuu⁻¹Kuf[:,:] = Kuu \ Kuf # Kuu⁻¹Kuf 
+    precomp.Kuu⁻¹KufΣ⁻¹y[:] = vec(Kuu \ (Kuf * alpha)) # Kuu⁻¹Kuf Σ⁻1 y appears repeatedly, so pre-compute
+    precomp.Σ⁻¹Kfu[:,:] = cK \ (Kuf') # TODO: reduce memory allocations
+    return precomp
+end
+function dmll_kern!(dmll::AbstractVector, gp::GPBase, precomp::SoRPrecompute, covstrat::SubsetOfRegsStrategy)
+    return dmll_kern!(dmll, gp.kernel, gp.x, gp.cK, gp.data, gp.alpha, 
+                      precomp.Kuu⁻¹Kuf, precomp.Kuu⁻¹KufΣ⁻¹y, precomp.Σ⁻¹Kfu,
+                      precomp.∂Kuu, precomp.∂Kfu,
+                      covstrat)
+end
+"""
+    dmll_noise(gp::GPE, precomp::SoRPrecompute)
+
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
+
+∂Σ = I for derivative wrt σ², so
+∂logp(Y|θ) = 1/2 y' Σ⁻¹ Σ⁻¹ y - 1/2 tr(Σ⁻¹)
+            = 1/2[ dot(α,α) - tr(Σ⁻¹) ]
+
+Σ⁻¹ = σ⁻²I - σ⁻⁴ Kuf'(Kuu + σ⁻² Kuf Kuf')⁻¹ Kuf
+    = σ⁻²I - σ⁻⁴ Kuf'(       ΣQR        )⁻¹ Kuf
+"""
+function dmll_noise(gp::GPE, precomp::SoRPrecompute, covstrat::SubsetOfRegsStrategy)
+    nobs = gp.nobs
+    cK = gp.cK
+    Lk = whiten(cK.ΣQR_PD, cK.Kuf)
+    return exp(2*gp.logNoise) * (
+        dot(gp.alpha, gp.alpha) 
+        - exp(-2*gp.logNoise) * nobs
+        + exp(-4*gp.logNoise)  * dot(Lk, Lk)
+        )
+end
+
+"""
+    dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, ααinvcKI::AbstractMatrix, covstrat::SubsetOfRegsStrategy)
+
+Derivative of the log likelihood under the Subset of Regressors (SoR) approximation.
+
+Helpful reference: Vanhatalo, Jarno, and Aki Vehtari. 
+                   "Sparse log Gaussian processes via MCMC for spatial epidemiology." 
+                   In Gaussian processes in practice, pp. 73-89. 2007.
+
+Generally, for a multivariate normal with zero mean
+    ∂logp(Y|θ) = 1/2 y' Σ⁻¹ ∂Σ Σ⁻¹ y - 1/2 tr(Σ⁻¹ ∂Σ)
+                    ╰───────────────╯     ╰──────────╯
+                           `V`                 `T`
+                       
+where Σ = Kff + σ²I.
+
+Notation: `f` is the observations, `u` is the inducing points.
+          ∂X stands for ∂X/∂θ, where θ is the kernel hyperparameters.
+
+In the SoR approximation, we replace Kff with Qff = Kfu Kuu⁻¹ Kuf
+
+∂Σ = ∂(Qff) = ∂(Kfu Kuu⁻¹ Kuf)
+            = ∂(Kfu) Kuu⁻¹ Kuf + Kfu ∂(Kuu⁻¹) Kuf + Kfu Kuu⁻¹ ∂(Kuf)
+
+∂(Kuu⁻¹) = -Kuu⁻¹ ∂(Kuu) Kuu⁻¹  --------^
+
+Also have pre-computed α = Σ⁻¹ y, so `V` can now be computed 
+efficiency (O(nm²) I think…) by careful ordering of the matrix multiplication steps.
+
+"""
+function dmll_kern!(dmll::AbstractVector, k::Kernel, X::AbstractMatrix, cK::SubsetOfRegsPDMat, data::KernelData, 
+                    alpha::AbstractVector, Kuu⁻¹Kuf, Kuu⁻¹KufΣ⁻¹y, Σ⁻¹Kfu, ∂Kuu, ∂Kfu,
+                    covstrat::SubsetOfRegsStrategy)
     dim, nobs = size(X)
     inducing = covstrat.inducing
     ninducing = size(inducing, 2)
     nparams = num_params(k)
+    Kuu = cK.Kuu
+    Kuf = cK.Kuf
     @assert nparams == length(dmll)
     dK_buffer = Vector{Float64}(undef, nparams)
     dmll[:] .= 0.0
-    Kuf = cK.Kuf
-    Kuu = cK.Kuu
-    ∂Kuu = Matrix{Float64}(undef, ninducing, ninducing)
-    ∂Kfu = Matrix{Float64}(undef, nobs, ninducing)
-    term = Kuu \ Kuf # Kuu⁻¹Kuf appears in multiple places, so pre-compute
     for iparam in 1:nparams
         grad_slice!(∂Kuu, k, inducing, inducing, EmptyData(), iparam)
         grad_slice!(∂Kfu, k, X, inducing,        EmptyData(), iparam)
-        ∂R = ∂Kfu * term
-        @inbounds for i in 1:nobs
-            ∂R[i,i] *= 2
-            for j in 1:(i-1)
-                s = ∂R[i,j] + ∂R[j,i]
-                ∂R[i,j] = s
-                ∂R[j,i] = s
-            end
-        end
-        ∂R -= term' * ∂Kuu * term
-        dmll[iparam] = dot(ααinvcKI, ∂R)/2
+        V =  2 * dot(alpha, ∂Kfu * (Kuu⁻¹KufΣ⁻¹y))    # = 2 y' Σ⁻¹ ∂Kfu Kuu⁻¹ Kuf Σ⁻¹y
+        V -= dot(Kuu⁻¹KufΣ⁻¹y, ∂Kuu * (Kuu⁻¹KufΣ⁻¹y)) # = y' Σ⁻¹ Kfu ∂(Kuu⁻¹) Kuf Σ⁻¹ y
+
+        T = 2 * dot(cK \ ∂Kfu, Kuu⁻¹Kuf')              # = 2 tr(Kuu⁻¹ Kuf Σ⁻¹ ∂Kfu)
+        T -=    dot(Σ⁻¹Kfu',  (Kuu \ ∂Kuu) * Kuu⁻¹Kuf) # = tr(Kuu⁻¹ Kuf Σ⁻¹ Kfu Kuu⁻¹ ∂Kuu)
+
+        # # BELOW FOR DEBUG ONLY
+        # ∂Σ = ∂Kfu * Kuu⁻¹Kuf
+        # @inbounds for i in 1:nobs
+            # ∂Σ[i,i] *= 2
+            # for j in 1:(i-1)
+                # s = ∂Σ[i,j] + ∂Σ[j,i]
+                # ∂Σ[i,j] = s
+                # ∂Σ[j,i] = s
+            # end
+        # end
+        # ∂Σ -= Kuu⁻¹Kuf' * ∂Kuu * Kuu⁻¹Kuf
+        # Valt = alpha'*∂Σ*alpha
+        # Talt = tr(cK \ ∂Σ)
+        # @show V, Valt
+        # @show T, Talt
+        # dmll_alt = dot(ααinvcKI, ∂Σ)/2
+        # @show dmll_alt, dmll[iparam]
+        # # ABOVE FOR DEBUG ONLY
+
+        dmll[iparam] = (V-T)/2
     end
     return dmll
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,9 +14,9 @@ function map_column_pairs(f, X::AbstractMatrix, Y::AbstractMatrix)
 end
 
 function map_column_pairs(f, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    D = Array{eltype(X)}(undef, nobsv, nobsv)
-    for i in 1:nobsv
+    dim, nobs = size(X)
+    D = Array{eltype(X)}(undef, nobs, nobs)
+    for i in 1:nobs
         for j in 1:i
             @inbounds D[i,j] = f(X[:,i], X[:,j])
             if i != j; @inbounds D[j,i] = D[i,j]; end;
@@ -45,12 +45,12 @@ function map_column_pairs!(D::AbstractMatrix, f, X::AbstractMatrix, Y::AbstractM
 end
 
 function map_column_pairs!(D::AbstractMatrix, f, X::AbstractMatrix)
-    dim, nobsv = size(X)
-    size(D,1) == nobsv || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)",
-                                                       size(D,1), nobsv)))
-    size(D,2) == nobsv || throw(ArgumentError(@sprintf("D has %d columns, while X has %d columns (should be same)",
-                                                       size(D,2), nobsv)))
-    @inbounds for i in 1:nobsv
+    dim, nobs = size(X)
+    size(D,1) == nobs || throw(ArgumentError(@sprintf("D has %d rows, while X has %d columns (should be same)",
+                                                       size(D,1), nobs)))
+    size(D,2) == nobs || throw(ArgumentError(@sprintf("D has %d columns, while X has %d columns (should be same)",
+                                                       size(D,2), nobs)))
+    @inbounds for i in 1:nobs
         for j in 1:i
             D[i,j] = f(view(X,:,i), view(X,:,j))
             if i != j; D[j,i] = D[i,j]; end;

--- a/test/elastic.jl
+++ b/test/elastic.jl
@@ -13,7 +13,7 @@ using Test, GaussianProcesses
             gp2 = ElasticGPE(x0, y0, m, k, -2.)
             append!(gp2, x[:, 1:7], y[1:7])
             append!(gp2, x[:, 8], y[8])
-            append!(gp2, x[:, 9:20], y[9:20])
+            append!(gp2, x[:, 9:nobs], y[9:nobs])
             @test gp1.cK.chol.U ≈ view(gp2.cK.chol).U
             xtest = rand(N, 2)
             mu1, sig1 = predict_y(gp1, xtest)
@@ -22,10 +22,15 @@ using Test, GaussianProcesses
             @test isapprox(sig1, sig2, atol = 1e-6)
             @test isapprox(gp1.mll, gp2.mll, atol = 1e-6)
             @test isapprox(gp1.alpha, gp2.alpha, atol = 1e-6)
-            optimize!(gp1)
-            optimize!(gp2)
-            @test isapprox(gp1.mll, gp2.mll, atol = 1e-6)
-            @test isapprox(gp1.alpha, gp2.alpha, atol = 1e-6)
+            GaussianProcesses.update_target_and_dtarget!(gp1)
+            GaussianProcesses.update_target_and_dtarget!(gp2)
+            @test gp1.mll ≈ gp2.mll          atol = 1e-6
+            @test gp1.alpha ≈ gp2.alpha      atol = 1e-6
+            @test gp1.dtarget ≈ gp2.dtarget  atol=1e-6
+            optimize!(gp1, f_tol=1e-12, x_tol=1e-12)
+            optimize!(gp2, f_tol=1e-12, x_tol=1e-12)
+            @test isapprox(gp1.mll, gp2.mll, atol = 1e-4)
+            @test isapprox(gp1.alpha, gp2.alpha, atol = 1e-4)
         end
     end
     gp = ElasticGPE(N, kernel = SEIso(0., 0.), capacity = 50)

--- a/test/gp.jl
+++ b/test/gp.jl
@@ -1,6 +1,7 @@
 module TestGP
 using GaussianProcesses, ScikitLearnBase
 using Test, Random
+using LinearAlgebra: diag
 
 Random.seed!(1)
 
@@ -20,11 +21,15 @@ Random.seed!(1)
     # Verify that predictive mean at input observations
     # are the same as the output observations
     @testset "Predictive mean at obs locations" begin
-        y_pred, sig = predict_y(gp, X)
+        y_pred, σ2 = predict_y(gp, X)
         @test maximum(abs, gp.y - y_pred) ≈ 0.0 atol=0.1
+        y_pred, pred_cov = predict_y(gp, X; full_cov=true)
+        @test maximum(abs, gp.y - y_pred) ≈ 0.0 atol=0.1
+        @test σ2 == diag(pred_cov)
     end
     @testset "Predictive mean at test locations" begin
         y_pred, sig = predict_y(gp, Xtest)
+        y_pred, sig = predict_y(gp, Xtest; full_cov=true)
     end
 
     # ScikitLearn interface test

--- a/test/gp.jl
+++ b/test/gp.jl
@@ -16,7 +16,15 @@ Random.seed!(1)
     ntest = 5
     Xtest = randn(d, ntest)
 
+    @testset "GPE constructors" begin
+        gp = GP(X, y, mZero, kern)
+        gp = GPE(X, y, mZero, kern)
+        gp = GPE(X, y, mZero, kern, 1.2)
+        gp = GPE(X, y, mZero, kern, GaussianProcesses.Scalar(1.2))
+    end
+
     gp = GP(X, y, mZero, kern)
+
 
     # Verify that predictive mean at input observations
     # are the same as the output observations

--- a/test/memory.jl
+++ b/test/memory.jl
@@ -1,6 +1,6 @@
 module TestMemory
 using Test, GaussianProcesses
-using GaussianProcesses: EmptyData
+using GaussianProcesses: EmptyData, init_precompute
 
 @testset "Memory Allocation" begin
     @testset "simple" begin
@@ -17,7 +17,7 @@ using GaussianProcesses: EmptyData
         # one for its Cholesky decomposition, and one for KernelData
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 3.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -35,7 +35,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GP(X, y, m, k, logNoise)
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 3.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -53,7 +53,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GP(X, y, m, k, logNoise)
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 3.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -71,7 +71,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GP(X, y, m, k, logNoise)
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 3.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -89,7 +89,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GP(X, y, m, k, logNoise)
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 4.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -107,7 +107,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GPE(X, y, m, k, logNoise, EmptyData())
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 2.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1
@@ -125,7 +125,7 @@ using GaussianProcesses: EmptyData
         mem = @allocated GPE(X, y, m, k, logNoise, EmptyData())
         matrix_bytes = (nobs^2)*64/8
         @test mem/matrix_bytes < 2.1
-        buf = Array{Float64}(undef, nobs, nobs)
+        buf = init_precompute(gp)
         GaussianProcesses.update_mll_and_dmll!(gp, buf)
         mem = @allocated GaussianProcesses.update_mll_and_dmll!(gp, buf)
         @test mem/matrix_bytes < 0.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ module TestGaussianProcesses
 @time include("elastic.jl")
 @time include("memory.jl")
 @time include("test_crossvalidation.jl")
+@time include("test_sparse.jl")
 end

--- a/test/test_crossvalidation.jl
+++ b/test/test_crossvalidation.jl
@@ -61,7 +61,7 @@ module TestCV
                 set_params!(gp, θprev; noise=true, kern=false, domean=false) # put it back
                 return CV
             end
-            grad_numerical = Calculus.gradient(target, [gp.logNoise])
+            grad_numerical = Calculus.gradient(target, Float64[gp.logNoise])
             update_mll!(gp)
             grad_analytical = GaussianProcesses.dlogpdθ_LOO(gp; noise=true, kern=false, domean=false)
             @test grad_numerical ≈ grad_analytical  atol=1e-6
@@ -125,7 +125,7 @@ module TestCV
                 set_params!(gp, θprev; noise=true, kern=false, domean=false) # put it back
                 return CV
             end
-            grad_numerical = Calculus.gradient(target, [gp.logNoise])
+            grad_numerical = Calculus.gradient(target, Float64[gp.logNoise])
             update_mll!(gp)
             grad_analytical = GaussianProcesses.dlogpdθ_CVfold(gp, folds; noise=true, kern=false, domean=false)
             @test grad_numerical ≈ grad_analytical  atol=1e-6

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -64,7 +64,7 @@ module TestSparse
 
         μpred, Σpred = predict_f(gp_sparse, xtest; full_cov=true)
 
-        # see Quiñonero-Candela & Rasmussen 2005, eq. 15
+        # see Quiñonero-Candela & Rasmussen 2005, eq. 19 and 23
         Qfx = getQab(cK, kernel, xtrain, xtest)
         Kxx = cov(kernel, xtest)
 

--- a/test/test_sparse.jl
+++ b/test/test_sparse.jl
@@ -1,0 +1,122 @@
+module TestSparse
+    using GaussianProcesses
+    using GaussianProcesses: get_params, set_params!, update_mll!, update_mll_and_dmll!, init_precompute, predictMVN, FullCovariance, SoR, FITC, DTC, SubsetOfRegsStrategy, DeterminTrainCondStrat, FullyIndepStrat, getQaa, getQab, predictMVN!
+    using Test, Random
+    using Distributions: Beta, Normal
+    using StatsBase: sample
+    import Calculus
+    using LinearAlgebra
+    using Statistics
+    using PDMats: PDMat
+
+    """ The true function we will be simulating from. """
+    function fstar(x::Float64)
+        return abs(x-5)*cos(2*x)
+    end
+
+    σy = 10.0
+    n=1000
+    ntest=30
+
+    Random.seed!(1)
+    Xdistr = Beta(7,7)
+    ϵdistr = Normal(0,σy)
+    x = rand(Xdistr, n)*10
+    Y = fstar.(x) .+ rand(ϵdistr,n)
+    k = SEIso(log(0.3), log(5.0))
+    gp_full = GPE(x', Y, MeanConst(mean(Y)), k, log(σy))
+    init_params = get_params(gp_full; noise=true, domean=true, kern=true)
+    set_params!(gp_full, init_params; noise=true, domean=true, kern=true)
+    update_mll!(gp_full)
+
+    Random.seed!(1)
+    Xu    = Matrix(sample(x, 10; replace=false)')
+    xtest = Matrix(rand(Xdistr, ntest)'.*10)
+
+    function test_pred(gp_sparse, cKPD::PDMat, covstrat::SubsetOfRegsStrategy)
+        cK = gp_sparse.cK
+        kernel = gp_sparse.kernel
+        meanf = gp_sparse.mean
+        mx = mean(meanf, xtest)
+        xtrain = gp_sparse.x
+        alpha = gp_sparse.alpha
+        σ2 = exp(2*gp_sparse.logNoise)
+
+        μpred, Σpred = predict_f(gp_sparse, xtest; full_cov=true)
+
+        # see Quiñonero-Candela & Rasmussen 2005, eq. 15
+        Qfx = getQab(cK, kernel, xtrain, xtest)
+        # Qff = getQaa(cK, kernel, xtrain)
+        Qxx = getQaa(cK, kernel, xtest)
+
+        μ_alt, Σ_alt = predictMVN!(Qxx, cKPD, Qfx, mx, alpha)
+        @test μ_alt ≈ μpred atol=1e-6
+        @test Σ_alt ≈ Σpred rtol=1e-3 # should this be better?
+    end
+    function test_pred(gp_sparse, cKPD::PDMat, covstrat::Union{DeterminTrainCondStrat,FullyIndepStrat})
+        cK = gp_sparse.cK
+        kernel = gp_sparse.kernel
+        meanf = gp_sparse.mean
+        mx = mean(meanf, xtest)
+        xtrain = gp_sparse.x
+        alpha = gp_sparse.alpha
+        σ2 = exp(2*gp_sparse.logNoise)
+
+        μpred, Σpred = predict_f(gp_sparse, xtest; full_cov=true)
+
+        # see Quiñonero-Candela & Rasmussen 2005, eq. 15
+        Qfx = getQab(cK, kernel, xtrain, xtest)
+        Kxx = cov(kernel, xtest)
+
+        μ_alt, Σ_alt = predictMVN!(Kxx, cKPD, Qfx, mx, alpha)
+        @test μ_alt ≈ μpred atol=1e-6
+        @test Σ_alt ≈ Σpred rtol=1e-3 # should this be better?
+    end
+
+    function test_sparse(gp_sparse, expect_mll)
+        @test gp_sparse.mll ≈ gp_full.mll atol=10 # marginal loglik shouldn't be radically different
+        @test gp_sparse.mll ≈ expect_mll atol=1e-6 # from previous run, check this doesn't drift
+
+        cK = gp_sparse.cK
+        cKmat = Matrix(cK)
+        cKPD = PDMat(cKmat)
+
+        gp_fromsparse = let
+            gp = GPE(x', Y, MeanConst(mean(Y)), k, log(σy))
+            gp.cK = cKPD
+            update_mll!(gp; noise=false, kern=false, domean=true)
+            gp
+        end
+        @test gp_sparse.mll ≈ gp_fromsparse.mll atol=1e-6
+
+        @test tr(cK) ≈ tr(cKmat) rtol=1e-6
+        @test logdet(cK) ≈ logdet(cKmat) rtol=1e-6
+        xrand = randn(gp_sparse.nobs,2)
+        @test cKPD\xrand ≈ cK\xrand atol=1e-6
+
+        buf = init_precompute(gp_sparse)
+        update_mll_and_dmll!(gp_sparse, buf; noise=true, domean=true, kern=true)
+        grad_analytical = copy(gp_sparse.dmll)
+        grad_numerical = Calculus.gradient(init_params) do params
+            set_params!(gp_sparse, params; noise=true, domean=true, kern=true)
+            GaussianProcesses.update_mll!(gp_sparse)
+            t = gp_sparse.mll
+            set_params!(gp_sparse, init_params; noise=true, domean=true, kern=true)
+            t
+        end
+        @test grad_numerical ≈ grad_analytical  atol=1e-3
+        test_pred(gp_sparse, cKPD, gp_sparse.covstrat)
+    end
+
+    @testset "Sparse Approximations" begin
+        @testset "Subset of Regressors" begin
+            test_sparse(SoR(x', Xu, Y, gp_full.mean, gp_full.kernel, gp_full.logNoise), -3700.9442607193782)
+        end
+        @testset "Deterministic Training Conditionals" begin
+            test_sparse(DTC(x', Xu, Y, gp_full.mean, gp_full.kernel, gp_full.logNoise), -3700.9441871196145)
+        end
+        @testset "Fully Independent Training Conditionals" begin
+            test_sparse(FITC(x', Xu, Y, gp_full.mean, gp_full.kernel, gp_full.logNoise), -3706.716231927398)
+        end
+    end
+end


### PR DESCRIPTION
I've just finished implementing a very basic version of the Subset of Regressors (SoR) sparse approximation to GPs. But before I go any further with this, I want to discuss whether this is the right way to implement sparse approximations.

The idea is that sparse approximations will be represented as a special type of positive definite matrix. This makes some sense, as operations involving the covariance matrix are really where the sparsity comes in. One would also hope that this would play nicely with the MCMC approach.

Ideally, one would be able to just define the required methods for AbstractPDMat, like left-division and `whiten!`, just like @jbrea did for his `ElasticPDMat`, and then everything would just work. In fact for SoR I found that that implementing `\` and `logdet` was enough to compute the marginal loglikelihood. But for predictions there are three problems:
* I do not know how to implement `whiten!`, which is required for predictions. 
* The sparse representation also affects how the covariance between the test units and training units is computed.
* There are some simplifications for predictions that I just implemented directly in `_predict`.

I have not yet looked into computing derivatives of the marginal loglikelihood, which will also require some thought.

So the `AbstractPDMat` abstraction only took me so far. The other thing that bothers me is that the inducing points are stored inside the PDMat object, along with some precomputed matrices. To me this feels frail, as it means the sparse covariance matrix cannot be obtained from scratch, and state is distributed amongst various objects in a way that might be confusing to future developers.

In short, this does work, but I want to get some ideas and thoughts from you before I dive in any further.

An example:
```julia
using GaussianProcesses
using Distributions
using LaTeXStrings
using LinearAlgebra

import PyPlot; plt=PyPlot

# simulate some data
""" The true function we will be simulating from. """
function fstar(x::Float64)
    return abs(x-5)*cos(2*x)
end

σy = 10.0
n=10000

Xdistr = Beta(7,7)
ϵdistr = Normal(0,σy)
x = rand(Xdistr, n)*10
Y = fstar.(x) .+ rand(ϵdistr,n)

# fit a regular GP
k = SEIso(log(0.3), log(5.0))
gp = GPE(x', Y, MeanConst(mean(Y)), k, log(σy))
@time gp = GPE(x', Y, MeanConst(mean(Y)), k, log(σy))
# 6.952195 seconds (37 allocations: 2.235 GiB, 1.51% gc time)
# predictions from exact GP
μ_exact, Σ_exact = predict_f(gp, xx; full_cov=true)
@time predict_f(gp, xx; full_cov=true)
# 0.661820 seconds (918.97 k allocations: 76.883 MiB, 3.89% gc time)

# pick some inducing points at random
Xu = Matrix(sample(x, 10; replace=false)')

# fit a sparse GP
gp_SOR = GaussianProcesses.SoR(x', Xu, Y, MeanConst(mean(Y)), k, log(σy));
@time gp_SOR = GaussianProcesses.SoR(x', Xu, Y, MeanConst(mean(Y)), k, log(σy));
# 0.003469 seconds (53 allocations: 2.677 MiB)

gp_SOR.mll, gp.mll
# (-37216.77118274264, -37223.82480148437)

xx = range(0, stop=10, length=200)
μSORgp, ΣSORgp = predict_f(gp_SOR, xx; full_cov=true)
@time predict_f(gp_SOR, xx; full_cov=true);
# 0.001098 seconds (55 allocations: 851.766 KiB)

#=======
# Plot predictions
========#
cbbPalette = ["#E69F00", "#56B4E9", "#009E73", 
                "#F0E442", "#0072B2", "#D55E00", 
                "#CC79A7"];
plt.plot(x,Y, ".", color="black", markeredgecolor="None", alpha=0.1, label="simulated data")
plt.plot(xx, fstar.(xx), color=cbbPalette[2], label=L"f^\star(X)", linewidth=2)
plt.plot(xx, μ_exact, color=cbbPalette[3], label=L"$f(x) \mid Y, \hat\theta$")
plt.fill_between(xx, μ_exact.-sqrt.(diag(Σ_exact)), μ_exact.+sqrt.(diag(Σ_exact)), 
                 color=cbbPalette[3], alpha=0.3)
plt.plot(xx, μSORgp, color=cbbPalette[6], label=L"$f(x) \mid Y, \hat\theta$ SoR")
y_err = sqrt.(diag(ΣSORgp))
plt.fill_between(xx, μSORgp.-y_err, μSORgp.+y_err, 
                 color=cbbPalette[6], alpha=0.5)
plt.xlabel(L"X")
plt.ylabel(L"Y")
plt.title("Subset of Regressors")
plt.legend(loc="upper center", fontsize="small")
plt.ylim(-10,10)
plt.plot(Xu, zeros(Xu).-5, linestyle="None", 
    marker=6, markersize=12, color="black", label=L"inducing variables $X_\mathbf{u}$")
```

![index](https://user-images.githubusercontent.com/328831/49741563-99c23f80-fc8e-11e8-9808-e75718c0a926.png)

(Obviously in this case it's a pretty bad approximation, but that's beside the point!)