### PR TITLE
Implemented The Elliptical Slice Sampler

### DIFF
--- a/src/GP.jl
+++ b/src/GP.jl
@@ -51,7 +51,7 @@ end
 @inline subtract_Lck!(Sigma_raw, Lck) = Sigma_raw .-= Lck'Lck
 
 """
-    predict_f(gp::GPBase, X::Matrix{Float64}[; full_cov::Bool = false])
+    predict_f(gp::GPBase, X::Matrix{Float64}[]; full_cov::Bool = false)
 
 Return posterior mean and variance of the Gaussian Process `gp` at specfic points which are
 given as columns of matrix `X`. If `full_cov` is `true`, the full covariance matrix is
@@ -71,6 +71,24 @@ function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
             σ2[k] = max(diag(sig)[1], 0.0)
         end
         return μ, σ2
+    end
+end
+
+"""
+    predict_f(gp::GPBase, X::Vector{Float64}[]; full_cov::Bool = false)
+
+Return posterior mean and variance of the Gaussian Process `gp` at a specfic point which is
+given as the vector `x`. If `full_cov` is `true`, the full covariance matrix is
+returned instead of only the variance.
+"""
+function predict_f(gp::GPBase, x::AbstractVector; full_cov::Bool=false)
+    length(x) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
+    μ, σ2 = predict_full(gp, x[:,:])
+    if full_cov
+        return μ[1], σ2[1]
+    else
+        ## Calculate prediction for each point independently
+        return μ[1], max(diag(σ2)[1], 0.0)
     end
 end
 

--- a/src/GP.jl
+++ b/src/GP.jl
@@ -74,24 +74,6 @@ function predict_f(gp::GPBase, x::AbstractMatrix; full_cov::Bool=false)
     end
 end
 
-"""
-    predict_f(gp::GPBase, X::Vector{Float64}[]; full_cov::Bool = false)
-
-Return posterior mean and variance of the Gaussian Process `gp` at a specfic point which is
-given as the vector `x`. If `full_cov` is `true`, the full covariance matrix is
-returned instead of only the variance.
-"""
-function predict_f(gp::GPBase, x::AbstractVector; full_cov::Bool=false)
-    length(x) == gp.dim || throw(ArgumentError("Gaussian Process object and input observations do not have consistent dimensions"))
-    μ, σ2 = predict_full(gp, x[:,:])
-    if full_cov
-        return μ[1], σ2[1]
-    else
-        ## Calculate prediction for each point independently
-        return μ[1], max(diag(σ2)[1], 0.0)
-    end
-end
-
 # 1D Case for prediction of process
 predict_f(gp::GPBase, x::AbstractVector, args...; kwargs...) = predict_f(gp, x', args...; kwargs...)
 # 1D Case for prediction of observations

--- a/src/GPE.jl
+++ b/src/GPE.jl
@@ -393,6 +393,32 @@ function predict_y(gp::GPE, x::AbstractMatrix; full_cov::Bool=false)
     end
 end
 
+#—————————————————————————————————————————————————————–
+# Function for sampling from the prior of the GP object hyperparameters.
+
+function sample_params(gp::GPE; noise::Bool=true, domean::Bool=true, kern::Bool=true)
+    samples = Float64[]
+    if noise
+        noise_priors = get_priors(gp.logNoise)
+        @assert !isempty(noise_priors) "prior distributions of logNoise should be set"
+        noise_sample = rand(Product(noise_priors))
+        push!(samples, noise_sample...)
+    end
+
+    if domean
+        mean_priors = get_priors(gp.mean)
+        @assert !isempty(mean_priors) "prior distributions of mean should be set"
+        mean_sample = rand(Product(mean_prior))
+        append!(samples, mean_sample...)
+    end
+    if kern
+        kernel_priors = get_priors(gp.kernel)
+        @assert !isempty(kernel_priors) "prior distributions of kernel should be set"
+        kernel_sample = rand(Product(kernel_priors))
+        append!(samples, kernel_sample...)
+    end
+    return samples
+end
 
 #—————————————————————————————————————————————————————–
 #Functions for setting and calling the parameters of the GP object

--- a/src/GPMC.jl
+++ b/src/GPMC.jl
@@ -321,6 +321,33 @@ end
 
 appendlikbounds!(lb, ub, gp::GPMC, bounds) = appendbounds!(lb, ub, num_params(gp.lik), bounds)
 
+#—————————————————————————————————————————————————————–
+# Function for sampling from the prior of the GP object hyperparameters.
+
+function sample_param(gp::GPMC; noise::Bool=true, domean::Bool=true, kern::Bool=true)
+    samples = Float64[]
+    if noise
+        noise_priors = get_priors(gp.logNoise)
+        @assert !isempty(noise_priors) "prior distributions of logNoise hyperparameters should be set"
+        noise_sample = rand(Product(noise_prior))
+        push!(samples, noise_sample...)
+    end
+
+    if domean
+        mean_priors = get_priors(gp.mean)
+        @assert !isempty(mean_priors) "prior distributions of mean hyperparameters should be set"
+        mean_sample = rand(Product(mean_prior))
+        append!(samples, mean_sample...)
+    end
+    if kern
+        kernel_priors = get_priors(gp.kernel)
+        @assert !isempty(kernel_priors) "prior distributions of kernel hyperparameters should be set"
+        kernel_sample = rand(Product(kernel_prior))
+        append!(samples, kernel_sample...)
+    end
+    return samples
+end
+
 function get_params(gp::GPMC; lik::Bool=true, domean::Bool=true, kern::Bool=true)
     params = Float64[]
     append!(params, gp.v)

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -14,7 +14,7 @@ import PDMats: dim, Matrix, diag, pdadd!, *, \, inv, logdet, eigmax, eigmin, whi
 export GPBase, GP, GPE, GPMC, ElasticGPE, predict_f, predict_y, Kernel, Likelihood, CompositeKernel, SumKernel, ProdKernel, Masked, FixedKernel, fix, Noise, Const, SE, SEIso, SEArd, Periodic, Poly, RQ, RQIso, RQArd, Lin, LinIso, LinArd, Matern, Mat12Iso, Mat12Ard, Mat32Iso, Mat32Ard, Mat52Iso, Mat52Ard, #kernel functions
     MeanZero, MeanConst, MeanLin, MeanPoly, SumMean, ProdMean, MeanPeriodic, #mean functions
     GaussLik, BernLik, ExpLik, StuTLik, PoisLik, BinLik,       #likelihood functions
-    mcmc, optimize!,                                           #inference functions
+    mcmc, ess, optimize!,                                      #inference functions
     set_priors!,set_params!, update_target!, autodiff
 using ForwardDiff: GradientConfig, Dual, partials, copyto!, Chunk
 import ForwardDiff: seed!


### PR DESCRIPTION
Implemented the elliptical slice sampler (ESS) as described in,
```
Murray, Iain, Ryan P. Adams, and David JC MacKay. "Elliptical slice sampling." 
Journal of Machine Learning Research 9 (2010): 541-548.
```
I named the function as `ess` but please change it accordingly.
I think changing  `mcmc` to `hmc` would be more an appropriate but breaking change?
To implement sampling from the hyperparameter priors, I added `sample_params` in both `GPE.jl` and `GPMC.jl`
I didn't have the time to benchmark against HMC but I believe ESS is much more efficient.
Also, ESS doesn't have any hyperparameters so it's pretty easy to use.

I have one question though,
why `post` in `hmc` is row-major while the adjoint is returned?
I think declaring it in column-major order would be more efficient and cleaner.