### PR TITLE
Update ScikitLearn.jl

### DIFF
--- a/src/ScikitLearn.jl
+++ b/src/ScikitLearn.jl
@@ -4,7 +4,7 @@ import ScikitLearnBase
 
 ScikitLearnBase.is_classifier(::GPE) = false
 
-ScikitLearnBase.fit!(gp::GPE, X::AbstractMatrix, y::AbstractVector) = fit!(gp, X', y)
+ScikitLearnBase.fit!(gp::GPE, X::AbstractMatrix, y::AbstractVector) = fit!(gp, permutedims(X), y)
 
 function ScikitLearnBase.predict(gp::GPE, X::AbstractMatrix; eval_MSE::Bool=false)
     mu, Sigma = predict_y(gp, X'; full_cov=false)


### PR DESCRIPTION
**Hi**,
This PR fixes a bug in interface code to `ScikitLearn.jl`. see issue #149 for context.
An alternative solution would be to make the definition of `fit!` less restrictive as
```julia
function fit!(gp::GPE, x::AbstractMatrix, y::AbstractVector)
    length(y) == size(x,2) || throw(ArgumentError("Input and output observations must have consistent dimensions."))
    gp.x = x
    gp.y = y
    gp.data = KernelData(gp.kernel, x, x, gp.covstrat)
    gp.cK = alloc_cK(gp.covstrat, length(y))
    gp.dim, gp.nobs = size(x)
    initialise_target!(gp)
end
```