### PR TITLE
Add BibTeX syntax color highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package is still under development. If you have any suggestions to improve 
 
 To cite GaussianProcesses.jl, please reference the [arXiv paper](https://arxiv.org/abs/1812.09064). Sample Bibtex is given below:
 
-```
+```bibtex
 @article{gaussianprocesses.jl,
   title={GaussianProcesses. jl: A Nonparametric Bayes package for the Julia Language},
   author={Fairbrother, Jamie and Nemeth, Christopher and Rischard, Maxime and Brea, Johanni and Pinder, Thomas},


### PR DESCRIPTION
Github recently added support for BibTeX highlighting in linguist.