### PR TITLE
Remove obsolete Zygote dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Distances = "0.7, 0.8, 0.9, 0.10"
@@ -39,7 +38,6 @@ ScikitLearnBase = "0.4, 0.5"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0"
 StaticArrays = "0.6, 0.9, 0.12, 1.0"
 StatsFuns = "0.7, 0.8, 0.9"
-Zygote = "0.3, 0.4, 0.5, 0.6"
 julia = "1"
 
 [extras]

--- a/src/GaussianProcesses.jl
+++ b/src/GaussianProcesses.jl
@@ -1,6 +1,6 @@
 module GaussianProcesses
 
-using Optim, PDMats, ElasticPDMats, ElasticArrays, Distances, FastGaussQuadrature, RecipesBase, Distributions, Zygote, ProgressMeter
+using Optim, PDMats, ElasticPDMats, ElasticArrays, Distances, FastGaussQuadrature, RecipesBase, Distributions, ProgressMeter
 using StaticArrays
 using StatsFuns, SpecialFunctions
 


### PR DESCRIPTION
As far as I can tell, Zygote is no longer used anywhere in the GaussianProcesses.jl code. This PR simply removes Zygote as a dependency from the package.