### PR TITLE
fix warning for seriescolor for gp plot

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -18,7 +18,7 @@
             seriestype := :path
             ribbon := err
             fillcolor --> :lightblue
-            color --> :black
+            seriescolor --> :black
             x,y
         end
         if obsv


### PR DESCRIPTION
Attached is IJulia warning when I plot my gp; possible fix included in this pull request.
![Screen Shot 2021-07-05 at 8 53 59 AM](https://user-images.githubusercontent.com/20742294/124483316-cf106a80-dd6f-11eb-9a5e-b6d099d60173.png)
