### PR TITLE
Add 1D plot recipe labels

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -19,6 +19,7 @@
             ribbon := err
             fillcolor --> :lightblue
             seriescolor --> :black
+            label --> "Mean with $β credible bands"
             x,y
         end
         if obsv
@@ -26,6 +27,7 @@
                 seriestype := :scatter
                 markershape := :circle
                 markercolor := :black
+                label --> "Data"
                 gp.x', gp.y
             end
         end


### PR DESCRIPTION
The default plotting recipe is great but is ambiguous about what the plotted ribbon actually means. 
Adding a default label would make this much more obvious